### PR TITLE
Add springio/antora-xref-extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
-                "@antora/lunr-extension": "^1.0.0-alpha.8"
+                "@antora/lunr-extension": "^1.0.0-alpha.8",
+                "@springio/antora-xref-extension": "^1.0.0-alpha.4"
             },
             "devDependencies": {
                 "@asciidoctor/tabs": "^1.0.0-beta.6",
@@ -351,6 +352,14 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@springio/antora-xref-extension": {
+            "version": "1.0.0-alpha.4",
+            "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+            "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ==",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/abort-controller": {
@@ -2623,6 +2632,11 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@springio/antora-xref-extension": {
+            "version": "1.0.0-alpha.4",
+            "resolved": "https://registry.npmjs.org/@springio/antora-xref-extension/-/antora-xref-extension-1.0.0-alpha.4.tgz",
+            "integrity": "sha512-ybIqQaNgK2pjAkOAd/A+IXK5AmxDZcKfpsp528UXIG2N3L4KFwvwljhANHktS0HHiN5QMZp0PuD0WZsClpenhQ=="
         },
         "abort-controller": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "http-server": "^14.1.1"
     },
     "dependencies": {
-        "@antora/lunr-extension": "^1.0.0-alpha.8"
+        "@antora/lunr-extension": "^1.0.0-alpha.8",
+        "@springio/antora-xref-extension": "^1.0.0-alpha.4"
     }
 }

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -28,3 +28,4 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@springio/antora-xref-extension'

--- a/turtles-local-playbook.yml
+++ b/turtles-local-playbook.yml
@@ -25,6 +25,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@antora/lunr-extension'
+  - require: '@springio/antora-xref-extension'
 
 output:
   dir: build/site


### PR DESCRIPTION
Adds the [spring-io/antora-xref-extension](https://github.com/spring-io/antora-xref-extension) extension as Antora's built-in validation doesn't support xrefs with fragments (i.e. linking to the header of another file). 

Note, CI for this PR itself runs with the extension enabled and broken links of this type are considered `ERROR` level by the extension. If there are any such broken links, CI won't pass until the links are fixed.

Depends on https://github.com/rancher/turtles-product-docs/issues/34.