### PR TITLE
Sync Community - Prep v0.19

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "product-docs-supplemental-files"]
-	path = product-docs-supplemental-files
-	url = https://github.com/rancher/product-docs-supplemental-files.git
 [submodule "dsc-style-bundle"]
 	path = dsc-style-bundle
 	url = https://github.com/SUSEdoc/dsc-style-bundle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "product-docs-supplemental-files"]
 	path = product-docs-supplemental-files
 	url = https://github.com/rancher/product-docs-supplemental-files.git
+[submodule "dsc-style-bundle"]
+	path = dsc-style-bundle
+	url = https://github.com/SUSEdoc/dsc-style-bundle.git

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -10,11 +10,12 @@ content:
       start_paths: [versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
 
 
-ui: 
+# Description: SUSE UI bundle
+ui:
   bundle:
-    url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true
+    url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true
     snapshot: true
-  supplemental_files: ./product-docs-supplemental-files
+  supplemental_files: ./dsc-style-bundle/supplemental-files/rancher
 
 runtime:
   fetch: true

--- a/turtles-local-playbook.yml
+++ b/turtles-local-playbook.yml
@@ -7,6 +7,7 @@ content:
   sources:
     - url: ./
       start_paths: [versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
+      branches: HEAD
 
 # Description: SUSE UI bundle
 ui:

--- a/turtles-local-playbook.yml
+++ b/turtles-local-playbook.yml
@@ -12,9 +12,9 @@ content:
 # Description: SUSE UI bundle
 ui:
   bundle:
-    url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true
+    url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true
     snapshot: true
-  supplemental_files: ./product-docs-supplemental-files
+  supplemental_files: ./dsc-style-bundle/supplemental-files/rancher
 
 asciidoc:
   attributes:

--- a/versions/next/modules/en/pages/reference/certified.adoc
+++ b/versions/next/modules/en/pages/reference/certified.adoc
@@ -76,32 +76,45 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPG::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (virtual machines) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (GKE) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/next/modules/en/pages/reference/features.adoc
+++ b/versions/next/modules/en/pages/reference/features.adoc
@@ -2,7 +2,7 @@
 
 This section describes features and feature stages in {product_name}.
 
-== List of Beta and Alpha Features
+== List of Features
 
 |===
 | Feature | Helm Feature Name | Sub-Feature | Default | Stage 
@@ -14,10 +14,10 @@ This section describes features and feature stages in {product_name}.
 | alpha
 
 | *Add-on Provider Fleet*
-| `addon-provider-fleet`
+| _None_
 | _None_
 | enabled
-| beta
+| GA
 
 | *Agent TLS Mode*
 | `agent-tls-mode`

--- a/versions/next/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/next/modules/en/pages/tutorials/first-cluster.adoc
@@ -21,7 +21,7 @@ By inspecting the contents of this repository, you will find:
 
 . A *clusters* folder, which is where the manifests are stored.
 . *cluster1.yaml* is the CAPI workload cluster definition.
-. *fleet.yaml* is used to specify the configuration options for Fleet. In this case it's declaring that the cluster definition should be added to the `default` namespace.
+. *fleet.yaml* is used to specify the configuration options for Fleet. In this case it's declaring that the cluster definition should be added to the `capi-clusters` namespace.
 
 [NOTE]
 If you prefer, you can create your own Fleet repository using the same base structure.
@@ -67,7 +67,9 @@ export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.31.4
 export NAMESPACE=capi-clusters
 
-curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst > cluster1.yaml
+# use the SHELL-FORMAT in envsubst to ensure we replace only the
+# environment variables we exported above
+curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst '$CLUSTER_NAME,$CONTROL_PLANE_MACHINE_COUNT,$WORKER_MACHINE_COUNT,$KUBERNETES_VERSION,$NAMESPACE' > cluster1.yaml
 ----
 +
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.

--- a/versions/next/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/next/modules/en/pages/tutorials/first-cluster.adoc
@@ -13,7 +13,7 @@ This section will guide you through creating your first cluster and importing it
 ======
 GitOps using Fleet::
 +
-====
+--
 *Configure your Fleet repository*
 
 To simplify the process of cluster provisioning, we will be using a series of pre-configured examples that you can find in the repository https://github.com/rancher-sandbox/rancher-turtles-fleet-example.
@@ -48,17 +48,17 @@ image:gh_clone.png[git clone url]
 . Watch the resources become ready
 . Select *Cluster Management* from the menu
 . Check your cluster has been imported
-====
+--
 
 Manually using kubectl::
 +
-====
+--
 *Create your cluster definition*
 
 To generate the YAML for the cluster, do the following:
 
 . Open a terminal and run the following:
-+
+
 [source,bash]
 ----
 export CLUSTER_NAME=cluster1
@@ -71,11 +71,11 @@ export NAMESPACE=capi-clusters
 # environment variables we exported above
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst '$CLUSTER_NAME,$CONTROL_PLANE_MACHINE_COUNT,$WORKER_MACHINE_COUNT,$KUBERNETES_VERSION,$NAMESPACE' > cluster1.yaml
 ----
-+
+
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.
-+
+
 . Create the cluster using kubectl
-+
+
 [source,bash]
 ----
 kubectl create namespace capi-clusters
@@ -84,8 +84,7 @@ kubectl apply -f cluster1.yaml
 . Watch the resources become ready
 . Select *Cluster Management* from the menu
 . Check your cluster has been imported
-====
-
+--
 ======
 
 == Mark Namespace for auto-import

--- a/versions/next/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/next/modules/en/pages/tutorials/first-cluster.adoc
@@ -22,7 +22,7 @@ By inspecting the contents of this repository, you will find:
 . A *clusters* folder, which is where the manifests are stored.
 . *cluster1.yaml* is the CAPI workload cluster definition.
 . *fleet.yaml* is used to specify the configuration options for Fleet. In this case it's declaring that the cluster definition should be added to the `capi-clusters` namespace.
-
++
 [NOTE]
 If you prefer, you can create your own Fleet repository using the same base structure.
 
@@ -58,7 +58,7 @@ Manually using kubectl::
 To generate the YAML for the cluster, do the following:
 
 . Open a terminal and run the following:
-
++
 [source,bash]
 ----
 export CLUSTER_NAME=cluster1
@@ -75,7 +75,7 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.
 
 . Create the cluster using kubectl
-
++
 [source,bash]
 ----
 kubectl create namespace capi-clusters

--- a/versions/next/modules/en/pages/user/clusterclass.adoc
+++ b/versions/next/modules/en/pages/user/clusterclass.adoc
@@ -15,11 +15,11 @@ Azure::
 --
 To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure.
 
-Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
+Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription.
 Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details.
 
 * Provider installation
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -38,9 +38,9 @@ spec:
 ----
 
 * Identity setup
-
++
 A Secret containing the ADD Service Principal password need to be created first.  
-
++
 [source,bash]
 ----
 # Settings needed for AzureClusterIdentity used by the AzureCluster
@@ -52,13 +52,13 @@ export AZURE_CLIENT_SECRET="<Password>"
 # This secret will be referenced by the AzureClusterIdentity used by the AzureCluster
 kubectl create secret generic "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" --from-literal=clientSecret="${AZURE_CLIENT_SECRET}" --namespace "${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}"
 ----
-
++
 The AzureClusterIdentity can now be created to use the Service Principal identity.
 Note that the AzureClusterIdentity is a namespaced resource and it needs to be created in the same namespace as the Cluster. +
 For more information on best practices when using Azure identities, please refer to the official https://capz.sigs.k8s.io/topics/identities-use-cases[documentation].
-
++
 Note that some variables are left to the user to substitute.
-
++
 [source,yaml]
 ----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -84,7 +84,7 @@ AWS::
 To prepare the management Cluster, we are going to install the https://cluster-api-aws.sigs.k8s.io/[Cluster API Provider AWS], and create a secret with the required credentials to provision a new Cluster on AWS.
 
 * Credentials setup
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -101,12 +101,12 @@ type: Opaque
 stringData:
   AWS_B64ENCODED_CREDENTIALS: xxx
 ----
-
++
 The content of the string, `AWS_B64ENCODED_CREDENTIALS`, is a base64-encoded string containing the AWS credentials. You will need to use an AWS IAM user with administrative permissions so you can create the cloud resources to host the cluster.
 We recommend you use `clusterawsadm` to encode credentials to use with Cluster API Provider AWS. You can refer to the https://cluster-api-aws.sigs.k8s.io/clusterawsadm/clusterawsadm_bootstrap_credentials.html?highlight=bootstrap%20credentials#clusterawsadm-bootstrap-credentials[CAPA book] for more information.
-
++
 These are the variables you will need to export to authenticate with AWS and use `clusterawsadm` to generate the encoded string, which are linked to your IAM user:
-
++
 [source,bash]
 ----
 AWS_REGION
@@ -115,7 +115,7 @@ AWS_SECRET_ACCESS_KEY
 ----
 
 * Provider installation
-
++
 [source,yaml]
 ----
 ---
@@ -135,7 +135,7 @@ Docker::
 To prepare the management Cluster, we are going to install the Docker Cluster API Provider.
 
 * Infrastructure Docker provider installation
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -153,7 +153,7 @@ spec:
 ----
 
 * https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -202,7 +202,7 @@ Azure RKE2::
 +
 --
 * An Azure ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
@@ -210,11 +210,11 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 
 * Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly.
 For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI.
-
++
 We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
 This Add-on provider is installed by default with {product_name}.
 Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
@@ -222,12 +222,12 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 ----
 
 * Create the Azure Cluster from the example ClusterClass
-
++
 Note that some variables are left to the user to substitute.
 Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning.
 This immutable variable however will lead to issues when scaling or rolling out control plane nodes.
 A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod`.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -271,16 +271,16 @@ Azure AKS::
 +
 --
 * An Azure AKS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-aks-example.yaml
 ----
 
 * Create the Azure AKS Cluster from the example ClusterClass.
-
++
 Note that some variables are left to the user to substitute.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -321,7 +321,7 @@ AWS Kubeadm::
 +
 --
 * An AWS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/clusterclass-kubeadm-example.yaml
@@ -330,28 +330,28 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 * For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI.
 * The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional.
 * Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver].
-
++
 We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
 This Add-on provider is installed by default with {product_name}.
 Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying Calico and the EBS CSI Driver in the workload cluster.
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/aws/calico/helm-chart.yaml
 ----
-
++
 We will need to create a Fleet Bundle to deploy the AWS Cloud Controller Manager as the upstream Helm chart has limitations that retrict us from applying the desired configuration via CAPI Add-on Provider Fleet. We expect this to be a temporary solution until the official chart is capable of supporting our requirements.
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/fleet-bundle.yaml
 ----
 
 * Create the AWS Cluster from the example ClusterClass.
-
++
 Note that some variables are left to the user to substitute.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -394,27 +394,27 @@ Docker Kubeadm::
 +
 --
 * A Docker Kubeadm ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/clusterclass-docker-kubeadm.yaml
 ----
 
 * For this example we are also going to install Calico as the default CNI.
-
++
 We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
 This Add-on provider is installed by default with {product_name}.
 Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
 ----
 
 * Create the Docker Kubeadm Cluster from the example ClusterClass.
-
++
 Note that some variables are left to the user to substitute.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -449,25 +449,25 @@ Docker RKE2::
 +
 --
 * A Docker RKE2 ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/clusterclass-docker-rke2.yaml
 ----
 
 * For this example we are also going to install Calico as the default CNI.
-
++
 We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
 This Add-on provider is installed by default with {product_name}.
 Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
 ----
 
 * Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster.
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -531,7 +531,7 @@ data:
 ----
 
 * Create the Docker Kubeadm Cluster from the example ClusterClass.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/versions/next/modules/en/pages/user/clusterclass.adoc
+++ b/versions/next/modules/en/pages/user/clusterclass.adoc
@@ -10,15 +10,16 @@ In this section we cover using https://cluster-api.sigs.k8s.io/tasks/experimenta
 
 [tabs]
 ======
-
 Azure::
 +
-To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure. +
+--
+To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure.
+
 Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
-Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details. +
-+
+Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details.
+
 * Provider installation
-+
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -35,11 +36,11 @@ spec:
   type: infrastructure
   name: azure
 ----
-+
+
 * Identity setup
-+
+
 A Secret containing the ADD Service Principal password need to be created first.  
-+
+
 [source,bash]
 ----
 # Settings needed for AzureClusterIdentity used by the AzureCluster
@@ -51,13 +52,13 @@ export AZURE_CLIENT_SECRET="<Password>"
 # This secret will be referenced by the AzureClusterIdentity used by the AzureCluster
 kubectl create secret generic "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" --from-literal=clientSecret="${AZURE_CLIENT_SECRET}" --namespace "${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}"
 ----
-+
-The AzureClusterIdentity can now be created to use the Service Principal identity. +
+
+The AzureClusterIdentity can now be created to use the Service Principal identity.
 Note that the AzureClusterIdentity is a namespaced resource and it needs to be created in the same namespace as the Cluster. +
-For more information on best practices when using Azure identities, please refer to the official https://capz.sigs.k8s.io/topics/identities-use-cases[documentation]. +
-+
-Note that some variables are left to the user to substitute. +
-+
+For more information on best practices when using Azure identities, please refer to the official https://capz.sigs.k8s.io/topics/identities-use-cases[documentation].
+
+Note that some variables are left to the user to substitute.
+
 [source,yaml]
 ----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -75,13 +76,15 @@ spec:
   tenantID: <AZURE_TENANT_ID>
   type: ServicePrincipal
 ----
+--
 
 AWS::
 +
+--
 To prepare the management Cluster, we are going to install the https://cluster-api-aws.sigs.k8s.io/[Cluster API Provider AWS], and create a secret with the required credentials to provision a new Cluster on AWS.
-+
+
 * Credentials setup
-+
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -98,19 +101,21 @@ type: Opaque
 stringData:
   AWS_B64ENCODED_CREDENTIALS: xxx
 ----
-+
+
 The content of the string, `AWS_B64ENCODED_CREDENTIALS`, is a base64-encoded string containing the AWS credentials. You will need to use an AWS IAM user with administrative permissions so you can create the cloud resources to host the cluster.
 We recommend you use `clusterawsadm` to encode credentials to use with Cluster API Provider AWS. You can refer to the https://cluster-api-aws.sigs.k8s.io/clusterawsadm/clusterawsadm_bootstrap_credentials.html?highlight=bootstrap%20credentials#clusterawsadm-bootstrap-credentials[CAPA book] for more information.
-+
+
 These are the variables you will need to export to authenticate with AWS and use `clusterawsadm` to generate the encoded string, which are linked to your IAM user:
-+
+
 [source,bash]
+----
 AWS_REGION
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
-+
+----
+
 * Provider installation
-+
+
 [source,yaml]
 ----
 ---
@@ -122,13 +127,15 @@ metadata:
 spec:
   type: infrastructure
 ----
+--
 
 Docker::
 +
+--
 To prepare the management Cluster, we are going to install the Docker Cluster API Provider.
-+
+
 * Infrastructure Docker provider installation
-+
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -144,9 +151,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
+
 * https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-+
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -177,6 +184,7 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
+--
 ======
 
 
@@ -192,33 +200,34 @@ Examples using `HelmApps` need at least Rancher `v2.11`, or otherwise Fleet `v0.
 
 Azure RKE2::
 +
+--
 * An Azure ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
 ----
-+
-* Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
-For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-+
-We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
+
+* Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly.
+For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI.
+
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
+This Add-on provider is installed by default with {product_name}.
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
 ----
-+
-* Create the Azure Cluster from the example ClusterClass +
-+ 
-Note that some variables are left to the user to substitute. +
-Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning. +
-This immutable variable however will lead to issues when scaling or rolling out control plane nodes. +
-A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod` +
-+
+
+* Create the Azure Cluster from the example ClusterClass
+
+Note that some variables are left to the user to substitute.
+Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning.
+This immutable variable however will lead to issues when scaling or rolling out control plane nodes.
+A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod`.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -256,20 +265,22 @@ spec:
         name: md-0
         replicas: 3
 ----
+--
 
 Azure AKS::
 +
+--
 * An Azure AKS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-aks-example.yaml
 ----
-+
-* Create the Azure AKS Cluster from the example ClusterClass +
-+ 
-Note that some variables are left to the user to substitute. +
-+
+
+* Create the Azure AKS Cluster from the example ClusterClass.
+
+Note that some variables are left to the user to substitute.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -304,41 +315,43 @@ spec:
         name: worker-1
         replicas: 1
 ----
+--
 
 AWS Kubeadm::
 +
+--
 * An AWS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/clusterclass-kubeadm-example.yaml
 ----
-+
-* For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-* The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional. +
-* Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver]. +
-+
-We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying Calico and the EBS CSI Driver in the workload cluster. +
-+
+
+* For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI.
+* The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional.
+* Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver].
+
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
+This Add-on provider is installed by default with {product_name}.
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying Calico and the EBS CSI Driver in the workload cluster.
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/aws/calico/helm-chart.yaml
 ----
-+
-We will need to create a Fleet Bundle to deploy the AWS Cloud Controller Manager as the upstream Helm chart has limitations that retrict us from applying the desired configuration via CAPI Add-on Provider Fleet. We expect this to be a temporary solution until the official chart is capable of supporting our requirements. +
-+
+
+We will need to create a Fleet Bundle to deploy the AWS Cloud Controller Manager as the upstream Helm chart has limitations that retrict us from applying the desired configuration via CAPI Add-on Provider Fleet. We expect this to be a temporary solution until the official chart is capable of supporting our requirements.
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/fleet-bundle.yaml
 ----
-+
-* Create the AWS Cluster from the example ClusterClass +
-+ 
-Note that some variables are left to the user to substitute. +
-+
+
+* Create the AWS Cluster from the example ClusterClass.
+
+Note that some variables are left to the user to substitute.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -375,31 +388,33 @@ spec:
         name: md-0
         replicas: 1
 ----
+--
 
 Docker Kubeadm::
 +
+--
 * A Docker Kubeadm ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/clusterclass-docker-kubeadm.yaml
 ----
-+
+
 * For this example we are also going to install Calico as the default CNI.
-+
-We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
+
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
+This Add-on provider is installed by default with {product_name}.
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
 ----
-+
-* Create the Docker Kubeadm Cluster from the example ClusterClass +
-+ 
-Note that some variables are left to the user to substitute. +
-+
+
+* Create the Docker Kubeadm Cluster from the example ClusterClass.
+
+Note that some variables are left to the user to substitute.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -428,29 +443,31 @@ spec:
           name: md-0
           replicas: 3
 ----
+--
 
 Docker RKE2::
 +
+--
 * A Docker RKE2 ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/clusterclass-docker-rke2.yaml
 ----
-+
+
 * For this example we are also going to install Calico as the default CNI.
-+
-We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
+
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
+This Add-on provider is installed by default with {product_name}.
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
 ----
-+
-* Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster +
-+
+
+* Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster.
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -512,9 +529,9 @@ data:
       server {{ $server }} {{ $backend.Address }}:9345 check check-ssl verify none
       {{- end}}
 ----
-+
-* Create the Docker Kubeadm Cluster from the example ClusterClass +
-+
+
+* Create the Docker Kubeadm Cluster from the example ClusterClass.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -550,4 +567,5 @@ spec:
         name: md-0
         replicas: 3
 ----
+--
 ======

--- a/versions/next/modules/en/pages/user/clusterclass.adoc
+++ b/versions/next/modules/en/pages/user/clusterclass.adoc
@@ -1,6 +1,6 @@
 = ClusterClass
 
-In this section we cover using https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/[ClusterClass] with {product_name}.
+In this section we cover using https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-class/[ClusterClass] with the {product_name}.
 
 == Prerequisites
 
@@ -8,14 +8,15 @@ In this section we cover using https://cluster-api.sigs.k8s.io/tasks/experimenta
 
 == Setup
 
+[tabs]
+======
 
-=== Azure
-
-To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure.
-
-Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription.
-Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details.
-
+Azure::
++
+To prepare the management Cluster, we are going to install the https://capz.sigs.k8s.io/[Cluster API Provider Azure], and create a https://capz.sigs.k8s.io/topics/identities#service-principal[ServicePrincipal] identity to provision a new Cluster on Azure. +
+Before we start, a ServicePrincipal needs to be created, with at least Contributor access to an Azure subscription. +
+Refer to the https://capz.sigs.k8s.io/getting-started#setting-up-your-azure-environment[CAPZ documentation] for more details. +
++
 * Provider installation
 +
 [source,yaml]
@@ -34,7 +35,7 @@ spec:
   type: infrastructure
   name: azure
 ----
-
++
 * Identity setup
 +
 A Secret containing the ADD Service Principal password need to be created first.  
@@ -75,6 +76,110 @@ spec:
   type: ServicePrincipal
 ----
 
+AWS::
++
+To prepare the management Cluster, we are going to install the https://cluster-api-aws.sigs.k8s.io/[Cluster API Provider AWS], and create a secret with the required credentials to provision a new Cluster on AWS.
++
+* Credentials setup
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capa-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws
+  namespace: capa-system
+type: Opaque
+stringData:
+  AWS_B64ENCODED_CREDENTIALS: xxx
+----
++
+The content of the string, `AWS_B64ENCODED_CREDENTIALS`, is a base64-encoded string containing the AWS credentials. You will need to use an AWS IAM user with administrative permissions so you can create the cloud resources to host the cluster.
+We recommend you use `clusterawsadm` to encode credentials to use with Cluster API Provider AWS. You can refer to the https://cluster-api-aws.sigs.k8s.io/clusterawsadm/clusterawsadm_bootstrap_credentials.html?highlight=bootstrap%20credentials#clusterawsadm-bootstrap-credentials[CAPA book] for more information.
++
+These are the variables you will need to export to authenticate with AWS and use `clusterawsadm` to generate the encoded string, which are linked to your IAM user:
++
+[source,bash]
+AWS_REGION
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
++
+* Provider installation
++
+[source,yaml]
+----
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: aws
+  namespace: capa-system
+spec:
+  type: infrastructure
+----
+
+Docker::
++
+To prepare the management Cluster, we are going to install the Docker Cluster API Provider.
++
+* Infrastructure Docker provider installation
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capd-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: docker
+  namespace: capd-system
+spec:
+  type: infrastructure
+----
++
+* https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-bootstrap
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  name: kubeadm
+  type: bootstrap
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-control-plane
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  name: kubeadm
+  type: controlPlane
+----
+======
+
+
 == Create a Cluster from a ClusterClass
 
 [WARNING]
@@ -110,6 +215,9 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 * Create the Azure Cluster from the example ClusterClass +
 + 
 Note that some variables are left to the user to substitute. +
+Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning. +
+This immutable variable however will lead to issues when scaling or rolling out control plane nodes. +
+A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod` +
 +
 [source,yaml]
 ----
@@ -139,6 +247,8 @@ spec:
       value: <AZURE_RESOURCE_GROUP>
     - name: azureClusterIdentityName
       value: cluster-identity
+    - name: registrationMethod
+      value: internal-first
     version: v1.31.1+rke2r1
     workers:
       machineDeployments:
@@ -193,5 +303,251 @@ spec:
       - class: default-worker
         name: worker-1
         replicas: 1
+----
+
+AWS Kubeadm::
++
+* An AWS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/aws/clusterclass-kubeadm-example.yaml
+----
++
+* For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
+* The https://github.com/kubernetes/cloud-provider-aws[Cloud Controller Manager AWS] will need to be installed on each downstream Cluster for the nodes to be functional. +
+* Additionally, we will also enable https://github.com/kubernetes-sigs/aws-ebs-csi-driver[AWS EBS CSI Driver]. +
++
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
+This Add-on provider is installed by default with {product_name}. +
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. This will take care of deploying Calico and the EBS CSI Driver in the workload cluster. +
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/csi/aws/helm-chart.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/aws/calico/helm-chart.yaml
+----
++
+We will need to create a Fleet Bundle to deploy the AWS Cloud Controller Manager as the upstream Helm chart has limitations that retrict us from applying the desired configuration via CAPI Add-on Provider Fleet. We expect this to be a temporary solution until the official chart is capable of supporting our requirements. +
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/aws/fleet-bundle.yaml
+----
++
+* Create the AWS Cluster from the example ClusterClass +
++ 
+Note that some variables are left to the user to substitute. +
++
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+    cni: calico
+    cloud-provider: aws
+    csi: aws-ebs-csi-driver
+  name: aws-quickstart
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  topology:
+    class: aws-kubeadm-example
+    controlPlane:
+      replicas: 1
+    variables:
+    - name: region
+      value: eu-west-2
+    - name: sshKeyName
+      value: <AWS_SSH_KEY_NAME>
+    - name: controlPlaneMachineType
+      value: <AWS_CONTROL_PLANE_MACHINE_TYPE>
+    - name: workerMachineType
+      value: <AWS_NODE_MACHINE_TYPE>
+    version: v1.31.0
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: 1
+----
+
+Docker Kubeadm::
++
+* A Docker Kubeadm ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/clusterclass-docker-kubeadm.yaml
+----
++
+* For this example we are also going to install Calico as the default CNI.
++
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
+This Add-on provider is installed by default with {product_name}. +
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+----
++
+* Create the Docker Kubeadm Cluster from the example ClusterClass +
++ 
+Note that some variables are left to the user to substitute. +
++
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: docker-kubeadm-quickstart
+  labels:
+    cni: calico
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.96.0.0/24
+  topology:
+    class: docker-kubeadm-example
+    controlPlane:
+      replicas: 3
+    version: v1.31.6
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: md-0
+          replicas: 3
+----
+
+Docker RKE2::
++
+* A Docker RKE2 ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/docker/clusterclass-docker-rke2.yaml
+----
++
+* For this example we are also going to install Calico as the default CNI.
++
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
+This Add-on provider is installed by default with {product_name}. +
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
++
+[source,bash]
+----
+kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
+----
++
+* Create the LoadBalancer ConfigMap for Docker RKEv2 Cluster +
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docker-rke2-lb-config
+  annotations:
+    "helm.sh/resource-policy": keep
+data:
+  value: |-
+    # generated by kind
+    global
+      log /dev/log local0
+      log /dev/log local1 notice
+      daemon
+      # limit memory usage to approximately 18 MB
+      # (see https://github.com/kubernetes-sigs/kind/pull/3115)
+      maxconn 100000
+    resolvers docker
+      nameserver dns 127.0.0.11:53
+    defaults
+      log global
+      mode tcp
+      option dontlognull
+      # TODO: tune these
+      timeout connect 5000
+      timeout client 50000
+      timeout server 50000
+      # allow to boot despite dns don't resolve backends
+      default-server init-addr none
+    frontend stats
+      mode http
+      bind *:8404
+      stats enable
+      stats uri /stats
+      stats refresh 1s
+      stats admin if TRUE
+    frontend control-plane
+      bind *:{{ .FrontendControlPlanePort }}
+      {{ if .IPv6 -}}
+      bind :::{{ .FrontendControlPlanePort }};
+      {{- end }}
+      default_backend kube-apiservers
+    backend kube-apiservers
+      option httpchk GET /healthz
+      {{range $server, $backend := .BackendServers }}
+      server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
+      {{- end}}
+    frontend rke2-join
+      bind *:9345
+      {{ if .IPv6 -}}
+      bind :::9345;
+      {{- end }}
+      default_backend rke2-servers
+    backend rke2-servers
+      option httpchk GET /v1-rke2/readyz
+      http-check expect status 403
+      {{range $server, $backend := .BackendServers }}
+      server {{ $server }} {{ $backend.Address }}:9345 check check-ssl verify none
+      {{- end}}
+----
++
+* Create the Docker Kubeadm Cluster from the example ClusterClass +
++
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster 
+metadata:
+  name: docker-rke2-example
+  labels:
+    cni: calico
+  annotations:
+    cluster-api.cattle.io/upstream-system-agent: "true"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/24
+    serviceDomain: cluster.local
+  topology:
+    class: docker-rke2-example
+    controlPlane:
+      replicas: 3
+    variables:
+    - name: rke2CNI
+      value: none
+    - name: dockerImage
+      value: kindest/node:v1.31.6
+    version: v1.31.6+rke2r1
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: 3
 ----
 ======

--- a/versions/next/modules/en/pages/user/clusters.adoc
+++ b/versions/next/modules/en/pages/user/clusters.adoc
@@ -118,61 +118,7 @@ spec:
 
 Docker RKE2/Kubeadm::
 +
-* Rancher Manager cluster with {product_name} installed 
-* Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker], example of Docker provider installation:
-+
-[source,yaml]
-----
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capd-system
----
-apiVersion: turtles-capi.cattle.io/v1alpha1
-kind: CAPIProvider
-metadata:
-  name: docker
-  namespace: capd-system
-spec:
-  type: infrastructure
-----
-+
-** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example
-of Kubeadm installation:
-+
-[source,yaml]
-----
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capi-kubeadm-bootstrap-system
----
-apiVersion: turtles-capi.cattle.io/v1alpha1
-kind: CAPIProvider
-metadata:
-  name: kubeadm-bootstrap
-  namespace: capi-kubeadm-bootstrap-system
-spec:
-  name: kubeadm
-  type: bootstrap
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capi-kubeadm-control-plane-system
----
-apiVersion: turtles-capi.cattle.io/v1alpha1
-kind: CAPIProvider
-metadata:
-  name: kubeadm-control-plane
-  namespace: capi-kubeadm-control-plane-system
-spec:
-  name: kubeadm
-  type: controlPlane
-----
+* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
 
 vSphere RKE2/Kubeadm::
 +
@@ -329,72 +275,15 @@ kubectl create -f cluster1.yaml
 +
 . Deploy CNI
 +
-> Once cluster is created a CNI is required for Nodes to become ready. You can refere to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+> Once the cluster is created a CNI is required for Nodes to become ready. You can refer to the Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
 
 Docker RKE2::
 +
-To generate the YAML for the cluster, do the following:
-+
-. Open a terminal and run the following:
-+
-[source,bash,subs=attributes+]
-----
-export CLUSTER_NAME={cluster-name}
-export NAMESPACE={namespace}
-export CONTROL_PLANE_MACHINE_COUNT={control-plane-machine-count}
-export WORKER_MACHINE_COUNT={worker-machine-count}
-export RKE2_VERSION={kubernetes-version}+rke2r1
-export RKE2_CNI=calico
-export KUBERNETES_VERSION={kubernetes-version} # needed for the CAPI Docker provider to use proper image
-
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
-envsubst '${NAMESPACE} $\{CLUSTER_NAME} $\{WORKER_MACHINE_COUNT} $\{RKE2_VERSION} $\{RKE2_CNI} $\{CONTROL_PLANE_MACHINE_COUNT} $\{KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
-----
-+
-. View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
-+
-> The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
-
-. Create the cluster using kubectl
-+
-[source,bash]
-----
-kubectl create namespace ${NAMESPACE}
-kubectl create -f cluster1.yaml 
-----
+* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
 
 Docker Kubeadm::
 +
-To generate the YAML for the cluster, do the following:
-+
-. Open a terminal and run the following:
-+
-[source,bash,subs=attributes+]
-----
-export CLUSTER_NAME={cluster-name}
-export NAMESPACE={namespace}
-export CONTROL_PLANE_MACHINE_COUNT={control-plane-machine-count}
-export WORKER_MACHINE_COUNT={worker-machine-count}
-export KUBERNETES_VERSION={kubernetes-version}
-
-curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
-----
-+
-. View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
-+
-> The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
-
-. Create the cluster using kubectl
-+
-[source,bash]
-----
-kubectl create namespace ${NAMESPACE}
-kubectl create -f cluster1.yaml 
-----
-+
-. Deploy CNI
-+
-> Once cluster is created a CNI is required for Nodes to become ready. You can refere to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+* Following installation guide was moved here xref:../user/clusterclass.adoc[here]
 
 vSphere RKE2::
 +

--- a/versions/next/modules/en/pages/user/clusters.adoc
+++ b/versions/next/modules/en/pages/user/clusters.adoc
@@ -16,7 +16,7 @@ AWS EKS/RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,yaml]
 ----
 ---
@@ -44,7 +44,7 @@ spec:
 ----
 
 ** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---
@@ -84,12 +84,12 @@ GCP GKE::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,bash]
 ----
 export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp-credentials.json | base64 | tr -d '\n' )
 ----
-
++
 [source,yaml]
 ----
 ---
@@ -129,7 +129,7 @@ vSphere RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source, yaml]
 ----
 ---
@@ -158,7 +158,7 @@ spec:
 ----
 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---

--- a/versions/next/modules/en/pages/user/clusters.adoc
+++ b/versions/next/modules/en/pages/user/clusters.adoc
@@ -12,11 +12,11 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS EKS/RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation, follow the provider documentation if some options need to be customized:
+
 [source,yaml]
 ----
 ---
@@ -42,10 +42,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], 
-example of Kubeadm installation:
-+
+
+** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -77,19 +76,20 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
+--
 
 GCP GKE::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation, follow the provider documentation if some options need to be customized:
+
 [source,bash]
 ----
 export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp-credentials.json | base64 | tr -d '\n' )
 ----
-+
+
 [source,yaml]
 ----
 ---
@@ -115,18 +115,21 @@ metadata:
 spec:
   type: infrastructure
 ----
+--
 
 Docker RKE2/Kubeadm::
 +
+--
 * Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+--
 
 vSphere RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation, follow the provider documentation if some options need to be customized:
+
 [source, yaml]
 ----
 ---
@@ -153,10 +156,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example
-of Kubeadm installation:
-+
+
+** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -188,7 +190,7 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
-
+--
 ======
 
 == Create Your Cluster Definition
@@ -202,14 +204,15 @@ spec:
 ======
 AWS EC2 RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider.
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash,subs=attributes+]
@@ -227,7 +230,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -239,11 +242,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml
 ----
+--
 
 AWS EC2 Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash,subs=attributes+]
@@ -260,7 +265,7 @@ export WORKER_MACHINE_COUNT={worker-machine-count}
 
 curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/refs/heads/main/templates/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -272,25 +277,31 @@ curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-a
 kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml
 ----
-+
+
 . Deploy CNI
 +
 > Once the cluster is created a CNI is required for Nodes to become ready. You can refer to the Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+--
 
 Docker RKE2::
 +
+--
 * Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+--
 
 Docker Kubeadm::
 +
+--
 * Following installation guide was moved here xref:../user/clusterclass.adoc[here]
+--
 
 vSphere RKE2::
 +
+--
 Before creating a vSphere+RKE2 workload cluster, it is required to have a VM template with the necessary RKE2 binaries and dependencies. The template should already include RKE2 binaries if operating in an air-gapped environment, following the https://docs.rke2.io/install/airgap#tarball-method[tarball method]. You can find additional configuration details in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/vmware[CAPRKE2 repository].
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -313,18 +324,18 @@ export VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."
 export CPI_IMAGE_K8S_VERSION: "v1.31.0"
 export KUBERNETES_VERSION={kubernetes-version}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -332,15 +343,17 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
+--
 
 vSphere Kubeadm::
 +
+--
 Before creating a vSphere+kubeadm workload cluster, it is required to have a VM template with the necessary kubeadm binaries and dependencies. The template should already include kubeadm, kubelet, and kubectl if operating in an air-gapped environment, following the https://github.com/kubernetes-sigs/image-builder[image-builder project]. You can find additional configuration details in the https://github.com/kubernetes-sigs/cluster-api-provider-vsphere[CAPV repository].
-+
+
 A list of published machine images (OVAs) is available https://github.com/kubernetes-sigs/image-builder#kubernetes-versions-with-published-ovas[here].
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -363,18 +376,18 @@ export VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."
 export CPI_IMAGE_K8S_VERSION: "v1.31.0"
 export KUBERNETES_VERSION={kubernetes-version}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -382,11 +395,13 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
+--
 
 AWS EKS::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -394,18 +409,18 @@ export NAMESPACE={namespace}
 export WORKER_MACHINE_COUNT={worker-machine-count}
 export KUBERNETES_VERSION={kubernetes-version}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -413,11 +428,13 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
+--
 
 GCP GKE::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -427,18 +444,18 @@ export GCP_REGION=us-east4
 export GCP_NETWORK_NAME=default
 export WORKER_MACHINE_COUNT={worker-machine-count}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -446,7 +463,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/next/modules/en/pages/user/fleet.adoc
+++ b/versions/next/modules/en/pages/user/fleet.adoc
@@ -27,7 +27,8 @@ There are 2 options to provide the configuration. The first is using the Rancher
 [tabs]
 ======
 Using the Rancher Manager UI::
-
++
+--
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the menu.
 . Select *fleet-local* as the namespace from the top right.
@@ -43,9 +44,11 @@ Using the Rancher Manager UI::
 . Click *Create*.
 . Click on the *clusters* name.
 . Watch the resources become ready.
+--
 
 Manually using kubectl::
-
++
+--
 . Get the *HTTPS* clone URL from your git repo.
 . Create a new file called *repo.yaml*.
 . Add the following contents to the new file:
@@ -64,14 +67,14 @@ spec:
     - /classes
   targets: []
 ----
-+
+
 . Apply the file to the Rancher Manager cluster using *kubectl*:
 +
 [source,bash]
 ----
 kubectl apply -f repo.yaml
 ----
-+
+
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the side bar.
 . Select *fleet-local* as the namespace from the top right.
@@ -80,6 +83,7 @@ kubectl apply -f repo.yaml
 . Watch the resources become ready.
 . Select *Cluster Management* from the menu.
 . Check that your cluster has been imported.
+--
 ======
 
 === Import Cluster Definitions
@@ -89,7 +93,8 @@ Now that the classes have been imported, it's possible to use them with cluster 
 [tabs]
 ======
 Using the Rancher Manager UI::
-
++
+--
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the menu.
 . Select *fleet-local* as the namespace from the top right.
@@ -107,9 +112,11 @@ Using the Rancher Manager UI::
 . Watch the resources become ready.
 . Select *Cluster Management* from the menu.
 . Check that your cluster has been imported.
+--
 
 Manually using kubectl::
-
++
+--
 . Get the *HTTPS* clone URL from your git repo.
 . Create a new file called *repo.yaml*.
 . Add the following contents to the new file:
@@ -128,14 +135,14 @@ spec:
     - /clusters
   targets: []
 ----
-+
+
 . Apply the file to the Rancher Manager cluster using *kubectl*:
 +
 [source,bash]
 ----
 kubectl apply -f repo.yaml
 ----
-+
+
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the side bar.
 . Select *fleet-local* as the namespace from the top right.
@@ -144,4 +151,5 @@ kubectl apply -f repo.yaml
 . Watch the resources become ready.
 . Select *Cluster Management* from the menu.
 . Check that your cluster has been imported.
+--
 ======

--- a/versions/v0.11/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/versions/v0.11/modules/en/pages/reference-guides/providers/howto.adoc
@@ -12,27 +12,33 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS RKE2::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 AWS Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 Docker Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book]
+--
 ======
 
 == Create Your Cluster Definition
@@ -41,14 +47,15 @@ Docker Kubeadm::
 ======
 AWS RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider. 
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -64,7 +71,7 @@ clusterctl generate cluster cluster1 \
 --from https://github.com/rancher/cluster-api-provider-rke2/blob/main/samples/aws/internal/cluster-template.yaml \
 > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -75,11 +82,13 @@ clusterctl generate cluster cluster1 \
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -92,7 +101,7 @@ clusterctl generate cluster cluster1 \
 --from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/capa.yaml \
 > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -103,11 +112,13 @@ clusterctl generate cluster cluster1 \
 ----
  kubectl create -f cluster1.yaml
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -120,7 +131,7 @@ clusterctl generate cluster cluster1 \
 --from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml \
 > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -131,7 +142,7 @@ clusterctl generate cluster cluster1 \
 ----
 kubectl create -f cluster1.yaml 
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.12/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/versions/v0.12/modules/en/pages/reference-guides/providers/howto.adoc
@@ -12,27 +12,33 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS RKE2::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 AWS Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 Docker Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book]
+--
 ======
 
 == Create Your Cluster Definition
@@ -41,14 +47,15 @@ Docker Kubeadm::
 ======
 AWS RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider. 
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -64,7 +71,7 @@ clusterctl generate cluster cluster1 \
 --from https://github.com/rancher/cluster-api-provider-rke2/blob/main/samples/aws/internal/cluster-template.yaml \
 > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -75,11 +82,13 @@ clusterctl generate cluster cluster1 \
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -92,7 +101,7 @@ clusterctl generate cluster cluster1 \
 --from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/capa.yaml \
 > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -103,11 +112,13 @@ clusterctl generate cluster cluster1 \
 ----
  kubectl create -f cluster1.yaml
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -120,7 +131,7 @@ clusterctl generate cluster cluster1 \
 --from https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml \
 > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -131,7 +142,7 @@ clusterctl generate cluster cluster1 \
 ----
 kubectl create -f cluster1.yaml 
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.13/modules/en/pages/reference-guides/providers/certified.adoc
+++ b/versions/v0.13/modules/en/pages/reference-guides/providers/certified.adoc
@@ -69,27 +69,38 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/v0.13/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/versions/v0.13/modules/en/pages/reference-guides/providers/howto.adoc
@@ -12,27 +12,33 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS RKE2::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 AWS Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 Docker Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book]
+--
 ======
 
 == Create Your Cluster Definition
@@ -41,14 +47,15 @@ Docker Kubeadm::
 ======
 AWS RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider. 
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -63,7 +70,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -74,11 +81,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -90,7 +99,7 @@ export AWS_INSTANCE_TYPE=t3.medium
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/capa.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -101,11 +110,13 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
  kubectl create -f cluster1.yaml
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -117,7 +128,7 @@ export KUBERNETES_VERSION=v1.30.0
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -128,7 +139,7 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
 kubectl create -f cluster1.yaml 
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.14/modules/en/pages/reference-guides/providers/certified.adoc
+++ b/versions/v0.14/modules/en/pages/reference-guides/providers/certified.adoc
@@ -69,27 +69,38 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/v0.14/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/versions/v0.14/modules/en/pages/reference-guides/providers/howto.adoc
@@ -12,27 +12,33 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS RKE2::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 AWS Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 Docker Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book]
+--
 ======
 
 == Create Your Cluster Definition
@@ -41,14 +47,15 @@ Docker Kubeadm::
 ======
 AWS RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider. 
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -63,7 +70,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -74,11 +81,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -90,7 +99,7 @@ export AWS_INSTANCE_TYPE=t3.medium
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/capa.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -101,11 +110,13 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
  kubectl create -f cluster1.yaml
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -117,7 +128,7 @@ export KUBERNETES_VERSION=v1.30.0
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -128,7 +139,7 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
 kubectl create -f cluster1.yaml 
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.15/modules/en/pages/reference-guides/providers/certified.adoc
+++ b/versions/v0.15/modules/en/pages/reference-guides/providers/certified.adoc
@@ -74,27 +74,38 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/v0.15/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/versions/v0.15/modules/en/pages/reference-guides/providers/howto.adoc
@@ -12,27 +12,33 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS RKE2::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 AWS Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 Docker Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book]
+--
 ======
 
 == Create Your Cluster Definition
@@ -41,14 +47,15 @@ Docker Kubeadm::
 ======
 AWS RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider. 
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -63,7 +70,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -74,11 +81,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -90,7 +99,7 @@ export AWS_INSTANCE_TYPE=t3.medium
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/capa.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -101,11 +110,13 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
  kubectl create -f cluster1.yaml
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -117,7 +128,7 @@ export KUBERNETES_VERSION=v1.30.0
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -128,7 +139,7 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
 kubectl create -f cluster1.yaml 
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.16/modules/en/pages/reference-guides/providers/certified.adoc
+++ b/versions/v0.16/modules/en/pages/reference-guides/providers/certified.adoc
@@ -74,27 +74,38 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/v0.16/modules/en/pages/reference-guides/providers/howto.adoc
+++ b/versions/v0.16/modules/en/pages/reference-guides/providers/howto.adoc
@@ -12,27 +12,33 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS RKE2::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 AWS Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book] 
+--
 
 Docker Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../tasks/capi-operator/basic_cluster_api_provider_installation.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker] 
 ** https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm] 
 * **clusterctl** CLI - see https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl[install clusterctl from CAPI book]
+--
 ======
 
 == Create Your Cluster Definition
@@ -41,14 +47,15 @@ Docker Kubeadm::
 ======
 AWS RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider. 
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -63,7 +70,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -74,11 +81,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -90,7 +99,7 @@ export AWS_INSTANCE_TYPE=t3.medium
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/capa.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -101,11 +110,13 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
  kubectl create -f cluster1.yaml
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -117,7 +128,7 @@ export KUBERNETES_VERSION=v1.30.0
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -128,7 +139,7 @@ curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-
 ----
 kubectl create -f cluster1.yaml 
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.17/modules/en/nav.adoc
+++ b/versions/v0.17/modules/en/nav.adoc
@@ -6,7 +6,7 @@
 * Reference
 ** xref:reference/architecture.adoc[Architecture]
 ** xref:reference/glossary.adoc[Glossary]
-** xref:reference/features.adoc[Feature]
+** xref:reference/features.adoc[Features]
 ** xref:reference/certified.adoc[Certified Providers]
 * User Guide
 ** xref:user/clusters.adoc[Provision a CAPI cluster]
@@ -14,7 +14,7 @@
 ** xref:user/caapf.adoc[CAPI Addon Provider Fleet]
 * Operator Guide
 ** xref:operator/chart.adoc[Chart Configuration]
-** xref:operator/manual.adoc[Manual Installation]]
+** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/capiprovider.adoc[Install CAPI Providers]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
 ** xref:operator/certification.adoc[Provider Certification]

--- a/versions/v0.17/modules/en/pages/reference/certified.adoc
+++ b/versions/v0.17/modules/en/pages/reference/certified.adoc
@@ -76,27 +76,38 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/v0.17/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/v0.17/modules/en/pages/tutorials/first-cluster.adoc
@@ -22,7 +22,7 @@ By inspecting the contents of this repository, you will find:
 . A *clusters* folder, which is where the manifests are stored.
 . *cluster1.yaml* is the CAPI workload cluster definition.
 . *fleet.yaml* is used to specify the configuration options for Fleet. In this case it's declaring that the cluster definition should be added to the `default` namespace.
-
++
 [NOTE]
 If you prefer, you can create your own Fleet repository using the same base structure.
 

--- a/versions/v0.17/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/v0.17/modules/en/pages/tutorials/first-cluster.adoc
@@ -13,7 +13,7 @@ This section will guide you through creating your first cluster and importing it
 ======
 GitOps using Fleet::
 +
-====
+--
 *Configure your Fleet repository*
 
 To simplify the process of cluster provisioning, we will be using a series of pre-configured examples that you can find in the repository https://github.com/rancher-sandbox/rancher-turtles-fleet-example.
@@ -48,13 +48,13 @@ image:gh_clone.png[git clone url]
 . Watch the resources become ready
 . Select *Cluster Management* from the menu
 . Check your cluster has been imported
-====
+--
 
 Manually using kubectl::
 +
-====
+--
 *Create your cluster definition*
-+
+
 To generate the YAML for the cluster, do the following:
 
 . Open a terminal and run the following:
@@ -68,9 +68,9 @@ export KUBERNETES_VERSION=v1.30.0
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -80,8 +80,7 @@ kubectl create -f cluster1.yaml
 . Watch the resources become ready
 . Select *Cluster Management* from the menu
 . Check your cluster has been imported
-====
-
+--
 ======
 
 == Mark Namespace for auto-import

--- a/versions/v0.17/modules/en/pages/user/clusters.adoc
+++ b/versions/v0.17/modules/en/pages/user/clusters.adoc
@@ -12,11 +12,11 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS EKS/RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation, follow the provider documentation if some options need to be customized:
+
 [source,yaml]
 ----
 ---
@@ -42,10 +42,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], 
-example of Kubeadm installation:
-+
+
+** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -77,19 +76,20 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
+--
 
 Azure AKS::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for Azure], this is an example of Azure provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for Azure], this is an example of Azure provider installation, follow the provider documentation if some options need to be customized:
+
 [source,bash]
 ----
 export AZURE_CLIENT_SECRET="xxx"
 ----
-+
+
 [source,yaml]
 ----
 ---
@@ -115,19 +115,20 @@ metadata:
   namespace: default
 type: Opaque
 ----
+--
 
 GCP GKE::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation, follow the provider documentation if some options need to be customized:
+
 [source,bash]
 ----
 export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp-credentials.json | base64 | tr -d '\n' )
 ----
-+
+
 [source,yaml]
 ----
 ---
@@ -153,13 +154,15 @@ metadata:
 spec:
   type: infrastructure
 ----
+--
 
 Docker RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker], example of Docker provider installation:
-+
+
 [source,yaml]
 ----
 ---
@@ -176,10 +179,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example
-of Kubeadm installation:
-+
+
+** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -211,14 +213,15 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
+--
 
 vSphere RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation, follow the provider documentation if some options need to be customized:
+
 [source, yaml]
 ----
 ---
@@ -245,10 +248,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example
-of Kubeadm installation:
-+
+
+** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -280,7 +282,7 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
-
+--
 ======
 
 == Create Your Cluster Definition
@@ -289,14 +291,15 @@ spec:
 ======
 AWS EC2 RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider.
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash]
@@ -314,7 +317,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting yaml file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -325,11 +328,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 ----
 bash kubectl create -f cluster1.yaml
 ----
+--
 
 AWS EC2 Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -346,7 +351,7 @@ export WORKER_MACHINE_COUNT=1
 
 curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/refs/heads/main/templates/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -357,15 +362,17 @@ curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-a
 ----
  kubectl create -f cluster1.yaml
 ----
-+
+
 . Deploy CNI
 +
 > Once cluster is created a CNI is required for Nodes to become ready. You can refere to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+--
 
 Docker RKE2::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -379,7 +386,7 @@ export KUBERNETES_VERSION=v1.30.4 # needed for the CAPI Docker provider to use p
 
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -390,11 +397,13 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 ----
 kubectl create -f cluster1.yaml 
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
@@ -407,7 +416,7 @@ export KUBERNETES_VERSION=v1.30.4
 
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -418,17 +427,19 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 ----
 kubectl create -f cluster1.yaml 
 ----
-+
+
 . Deploy CNI
 +
 > Once cluster is created a CNI is required for Nodes to become ready. You can refere to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+--
 
 vSphere RKE2::
 +
+--
 Before creating a vSphere+RKE2 workload cluster, it is required to have a VM template with the necessary RKE2 binaries and dependencies. The template should already include RKE2 binaries if operating in an air-gapped environment, following the https://docs.rke2.io/install/airgap#tarball-method[tarball method]. You can find additional configuration details in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/vmware[CAPRKE2 repository].
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash]
 ----
 export CLUSTER_NAME=cluster1
@@ -451,33 +462,35 @@ export VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."
 export CPI_IMAGE_K8S_VERSION: "v1.30.0"
 export KUBERNETES_VERSION=v1.30.0
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
 ----
 kubectl apply -f cluster1.yaml
 ----
+--
 
 vSphere Kubeadm::
 +
+--
 Before creating a vSphere+kubeadm workload cluster, it is required to have a VM template with the necessary kubeadm binaries and dependencies. The template should already include kubeadm, kubelet, and kubectl if operating in an air-gapped environment, following the https://github.com/kubernetes-sigs/image-builder[image-builder project]. You can find additional configuration details in the https://github.com/kubernetes-sigs/cluster-api-provider-vsphere[CAPV repository].
-+
+
 A list of published machine images (OVAs) is available https://github.com/kubernetes-sigs/image-builder#kubernetes-versions-with-published-ovas[here].
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash]
 ----
 export CLUSTER_NAME=cluster1
@@ -500,29 +513,31 @@ export VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."
 export CPI_IMAGE_K8S_VERSION: "v1.30.0"
 export KUBERNETES_VERSION=v1.30.0
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
 ----
 kubectl apply -f cluster1.yaml
 ----
+--
 
 Azure AKS::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash]
 ----
 export CLUSTERCLASS_NAME=clusterclass1
@@ -535,29 +550,31 @@ export AZURE_SUBSCRIPTION_ID="xxx"
 export AZURE_CLIENT_ID="xxx"
 export AZURE_TENANT_ID="xxx"
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/azure-aks-topology.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
 ----
 kubectl apply -f cluster1.yaml
 ----
+--
 
 AWS EKS::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash]
 ----
 export CLUSTER_NAME=cluster1
@@ -565,29 +582,31 @@ export NAMESPACE=capi-clusters
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.30.4
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
 ----
 kubectl apply -f cluster1.yaml
 ----
+--
 
 GCP GKE::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash]
 ----
 export CLUSTER_NAME=cluster1
@@ -597,25 +616,25 @@ export GCP_REGION=us-east4
 export GCP_NETWORK_NAME=default
 export WORKER_MACHINE_COUNT=1
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
 ----
 kubectl apply -f cluster1.yaml
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.17/modules/en/pages/user/clusters.adoc
+++ b/versions/v0.17/modules/en/pages/user/clusters.adoc
@@ -16,7 +16,7 @@ AWS EKS/RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,yaml]
 ----
 ---
@@ -44,7 +44,7 @@ spec:
 ----
 
 ** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---
@@ -84,12 +84,12 @@ Azure AKS::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for Azure], this is an example of Azure provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,bash]
 ----
 export AZURE_CLIENT_SECRET="xxx"
 ----
-
++
 [source,yaml]
 ----
 ---
@@ -123,12 +123,12 @@ GCP GKE::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,bash]
 ----
 export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp-credentials.json | base64 | tr -d '\n' )
 ----
-
++
 [source,yaml]
 ----
 ---
@@ -162,7 +162,7 @@ Docker RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker], example of Docker provider installation:
-
++
 [source,yaml]
 ----
 ---
@@ -181,7 +181,7 @@ spec:
 ----
 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---
@@ -221,7 +221,7 @@ vSphere RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source, yaml]
 ----
 ---
@@ -250,7 +250,7 @@ spec:
 ----
 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---

--- a/versions/v0.18/modules/en/pages/reference/certified.adoc
+++ b/versions/v0.18/modules/en/pages/reference/certified.adoc
@@ -76,32 +76,45 @@ The following is a support matrix for each certified provider and their support 
 ======
 CAPZ::
 +
+--
 - **Full support** of `ClusterClass`: both managed (AKS) and unmanaged (virtual machines) clusters can be provisioned via topology.
+--
 
 CAPA::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (EC2-based) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (EKS) clusters: this is a work-in-progress.
+--
 
 CAPG::
 +
+--
 - **Supports** `ClusterClass` when provisioning unmanaged (virtual machines) clusters.
 - **Does not support** `ClusterClass` when provisioning managed (GKE) clusters: this is a work-in-progress.
+--
 
 CAPRKE2::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CABPK::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPV::
 +
+--
 - **Full support** of `ClusterClass`.
+--
 
 CAPD::
 +
+--
 - **Full support** of `ClusterClass`.
-
+--
 ======

--- a/versions/v0.18/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/v0.18/modules/en/pages/tutorials/first-cluster.adoc
@@ -13,7 +13,7 @@ This section will guide you through creating your first cluster and importing it
 ======
 GitOps using Fleet::
 +
-====
+--
 *Configure your Fleet repository*
 
 To simplify the process of cluster provisioning, we will be using a series of pre-configured examples that you can find in the repository https://github.com/rancher-sandbox/rancher-turtles-fleet-example.
@@ -48,11 +48,11 @@ image:gh_clone.png[git clone url]
 . Watch the resources become ready
 . Select *Cluster Management* from the menu
 . Check your cluster has been imported
-====
+--
 
 Manually using kubectl::
 +
-====
+--
 *Create your cluster definition*
 
 To generate the YAML for the cluster, do the following:
@@ -69,9 +69,9 @@ export NAMESPACE=capi-clusters
 
 curl -s https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles-fleet-example/templates/docker-rke2.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View *cluster1.yaml* to ensure there are no tokens. You can make any changes you want as well.
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -82,8 +82,7 @@ kubectl apply -f cluster1.yaml
 . Watch the resources become ready
 . Select *Cluster Management* from the menu
 . Check your cluster has been imported
-====
-
+--
 ======
 
 == Mark Namespace for auto-import

--- a/versions/v0.18/modules/en/pages/tutorials/first-cluster.adoc
+++ b/versions/v0.18/modules/en/pages/tutorials/first-cluster.adoc
@@ -22,7 +22,7 @@ By inspecting the contents of this repository, you will find:
 . A *clusters* folder, which is where the manifests are stored.
 . *cluster1.yaml* is the CAPI workload cluster definition.
 . *fleet.yaml* is used to specify the configuration options for Fleet. In this case it's declaring that the cluster definition should be added to the `default` namespace.
-
++
 [NOTE]
 If you prefer, you can create your own Fleet repository using the same base structure.
 

--- a/versions/v0.18/modules/en/pages/user/clusterclass.adoc
+++ b/versions/v0.18/modules/en/pages/user/clusterclass.adoc
@@ -84,36 +84,36 @@ Examples using `HelmApps` need at least Rancher `v2.11`, or otherwise Fleet `v0.
 
 [tabs]
 ======
-
 Azure RKE2::
 +
+--
 * An Azure ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
 ----
-+
-* Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly. +
-For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI. +
-+
-We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet]. +
-This Add-on provider is installed by default with {product_name}. +
-Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors. +
-+
+
+* Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly.
+For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI.
+
+We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
+This Add-on provider is installed by default with {product_name}.
+Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/cni/calico/helm-chart.yaml
 ----
-+
-* Create the Azure Cluster from the example ClusterClass +
-+ 
-Note that some variables are left to the user to substitute. +
-Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning. +
-This immutable variable however will lead to issues when scaling or rolling out control plane nodes. +
-A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod` +
-+
+
+* Create the Azure Cluster from the example ClusterClass.
+
+Note that some variables are left to the user to substitute.
+Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning.
+This immutable variable however will lead to issues when scaling or rolling out control plane nodes.
+A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod`.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -151,20 +151,22 @@ spec:
         name: md-0
         replicas: 3
 ----
+--
 
 Azure AKS::
 +
+--
 * An Azure AKS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-+
+
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-aks-example.yaml
 ----
-+
-* Create the Azure AKS Cluster from the example ClusterClass +
-+ 
-Note that some variables are left to the user to substitute. +
-+
+
+* Create the Azure AKS Cluster from the example ClusterClass.
+
+Note that some variables are left to the user to substitute.
+
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -199,4 +201,5 @@ spec:
         name: worker-1
         replicas: 1
 ----
+--
 ======

--- a/versions/v0.18/modules/en/pages/user/clusterclass.adoc
+++ b/versions/v0.18/modules/en/pages/user/clusterclass.adoc
@@ -88,7 +88,7 @@ Azure RKE2::
 +
 --
 * An Azure ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
@@ -96,11 +96,11 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 
 * Additionally, the https://capz.sigs.k8s.io/self-managed/cloud-provider-config[Azure Cloud Provider] will need to be installed on each downstream Cluster, for the nodes to be initialized correctly.
 For this example we are also going to install https://docs.tigera.io/calico/latest/about/[Calico] as the default CNI.
-
++
 We can do this automatically at Cluster creation using the https://rancher-sandbox.github.io/cluster-api-addon-provider-fleet/[Cluster API Add-on Provider Fleet].
 This Add-on provider is installed by default with {product_name}.
 Two `HelmApps` need to be created first, to be applied on the new Cluster via label selectors.
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/applications/ccm/azure/helm-chart.yaml
@@ -108,12 +108,12 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 ----
 
 * Create the Azure Cluster from the example ClusterClass.
-
++
 Note that some variables are left to the user to substitute.
 Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning.
 This immutable variable however will lead to issues when scaling or rolling out control plane nodes.
 A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod`.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -157,16 +157,16 @@ Azure AKS::
 +
 --
 * An Azure AKS ClusterClass can be found among the https://github.com/rancher/turtles/tree/main/examples/clusterclasses[Turtles examples].
-
++
 [source,bash]
 ----
 kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/examples/clusterclasses/azure/clusterclass-aks-example.yaml
 ----
 
 * Create the Azure AKS Cluster from the example ClusterClass.
-
++
 Note that some variables are left to the user to substitute.
-
++
 [source,yaml]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/versions/v0.18/modules/en/pages/user/clusterclass.adoc
+++ b/versions/v0.18/modules/en/pages/user/clusterclass.adoc
@@ -110,6 +110,9 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/ma
 * Create the Azure Cluster from the example ClusterClass +
 + 
 Note that some variables are left to the user to substitute. +
+Also beware that the `internal-first` `registrationMethod` variable is used as a workaround for correct provisioning. +
+This immutable variable however will lead to issues when scaling or rolling out control plane nodes. +
+A https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525[patch] will support this case in a future release of CAPZ, but the Cluster will need to be reprovisioned to change the `registrationMethod` +
 +
 [source,yaml]
 ----
@@ -139,6 +142,8 @@ spec:
       value: <AZURE_RESOURCE_GROUP>
     - name: azureClusterIdentityName
       value: cluster-identity
+    - name: registrationMethod
+      value: internal-first
     version: v1.31.1+rke2r1
     workers:
       machineDeployments:

--- a/versions/v0.18/modules/en/pages/user/clusters.adoc
+++ b/versions/v0.18/modules/en/pages/user/clusters.adoc
@@ -16,7 +16,7 @@ AWS EKS/RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,yaml]
 ----
 ---
@@ -44,7 +44,7 @@ spec:
 ----
 
 ** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm],  example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---
@@ -84,12 +84,12 @@ GCP GKE::
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation, follow the provider documentation if some options need to be customized:
-
++
 [source,bash]
 ----
 export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp-credentials.json | base64 | tr -d '\n' )
 ----
-
++
 [source,yaml]
 ----
 ---
@@ -123,7 +123,7 @@ Docker RKE2/Kubeadm::
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker], example of Docker provider installation:
-
++
 [source,yaml]
 ----
 ---
@@ -142,7 +142,7 @@ spec:
 ----
 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---
@@ -183,7 +183,7 @@ vSphere RKE2/Kubeadm::
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation,
 follow the provider documentation if some options need to be customized:
-
++
 [source, yaml]
 ----
 ---
@@ -212,7 +212,7 @@ spec:
 ----
 
 ** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
-
++
 [source,yaml]
 ----
 ---

--- a/versions/v0.18/modules/en/pages/user/clusters.adoc
+++ b/versions/v0.18/modules/en/pages/user/clusters.adoc
@@ -12,11 +12,11 @@ Keep in mind that most Cluster API Providers are upstream projects maintained by
 ======
 AWS EKS/RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for AWS], this is an example of AWS provider installation, follow the provider documentation if some options need to be customized:
+
 [source,yaml]
 ----
 ---
@@ -42,10 +42,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], 
-example of Kubeadm installation:
-+
+
+** If using RKE2 or Kubeadm, it's required to have https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm],  example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -77,19 +76,20 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
+--
 
 GCP GKE::
 +
+--
 * Rancher Manager cluster with {product_name} installed
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
-** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation,
-follow the provider documentation if some options need to be customized:
-+
+** https://github.com/kubernetes-sigs/cluster-api-provider-gcp/[Infrastructure provider for GCP], this is an example of GCP provider installation, follow the provider documentation if some options need to be customized:
+
 [source,bash]
 ----
 export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp-credentials.json | base64 | tr -d '\n' )
 ----
-+
+
 [source,yaml]
 ----
 ---
@@ -115,13 +115,15 @@ metadata:
 spec:
   type: infrastructure
 ----
+--
 
 Docker RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api[Infrastructure provider for Docker], example of Docker provider installation:
-+
+
 [source,yaml]
 ----
 ---
@@ -138,10 +140,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example
-of Kubeadm installation:
-+
+
+** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -173,14 +174,16 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
+--
 
 vSphere RKE2/Kubeadm::
 +
+--
 * Rancher Manager cluster with {product_name} installed 
 * Cluster API Providers: you can find a guide on how to install a provider using the `CAPIProvider` resource xref:../operator/capiprovider.adoc[here]
 ** https://github.com/kubernetes-sigs/cluster-api-provider-aws/[Infrastructure provider for vSphere], this is an example of vSphere provider installation,
 follow the provider documentation if some options need to be customized:
-+
+
 [source, yaml]
 ----
 ---
@@ -207,10 +210,9 @@ metadata:
 spec:
   type: infrastructure
 ----
-+
-** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example
-of Kubeadm installation:
-+
+
+** https://github.com/rancher/cluster-api-provider-rke2[Bootstrap/Control Plane provider for RKE2](installed by default) or https://github.com/kubernetes-sigs/cluster-api[Bootstrap/Control Plane provider for Kubeadm], example of Kubeadm installation:
+
 [source,yaml]
 ----
 ---
@@ -242,7 +244,7 @@ spec:
   name: kubeadm
   type: controlPlane
 ----
-
+--
 ======
 
 == Create Your Cluster Definition
@@ -256,14 +258,15 @@ spec:
 ======
 AWS EC2 RKE2::
 +
+--
 Before creating an AWS+RKE2 workload cluster, it is required to build an AMI for the RKE2 version that is going to be installed on the cluster. You can follow the steps in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/image-builder#aws[RKE2 image-builder README] to build the AMI. 
-+
+
 We recommend you refer to the CAPRKE2 repository where you can find a https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws[samples folder] with different CAPA+CAPRKE2 cluster configurations that can be used to provision downstream clusters. The https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/internal[internal folder] contains cluster templates to deploy an RKE2 cluster on AWS using the internal cloud provider, and the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/aws/external[external folder] contains the cluster templates to deploy a cluster with the external cloud provider.
-+
+
 We will use the `internal` one for this guide, however the same steps apply for `external`. 
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following: 
 +
 [source,bash,subs=attributes+]
@@ -281,7 +284,7 @@ export AWS_AMI_ID="ami-id"
 
 curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs/heads/main/examples/templates/aws/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
@@ -293,11 +296,13 @@ curl -s https://raw.githubusercontent.com/rancher/cluster-api-provider-rke2/refs
 kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml
 ----
+--
 
 AWS EC2 Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash,subs=attributes+]
@@ -314,7 +319,7 @@ export WORKER_MACHINE_COUNT={worker-machine-count}
 
 curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/refs/heads/main/templates/cluster-template.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens (i.e. SSH keys or cloud credentials). You can make any changes you want as well. 
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -326,15 +331,17 @@ curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-a
 kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml
 ----
-+
+
 . Deploy CNI
 +
 > Once cluster is created a CNI is required for Nodes to become ready. You can refere to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+--
 
 Docker RKE2::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash,subs=attributes+]
@@ -350,7 +357,7 @@ export KUBERNETES_VERSION={kubernetes-version} # needed for the CAPI Docker prov
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-rke2.yaml -o docker-rke2.yaml
 envsubst '${NAMESPACE} $\{CLUSTER_NAME} $\{WORKER_MACHINE_COUNT} $\{RKE2_VERSION} $\{RKE2_CNI} $\{CONTROL_PLANE_MACHINE_COUNT} $\{KUBERNETES_VERSION}' < template-docker-rke2.yaml > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -362,11 +369,13 @@ envsubst '${NAMESPACE} $\{CLUSTER_NAME} $\{WORKER_MACHINE_COUNT} $\{RKE2_VERSION
 kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml 
 ----
+--
 
 Docker Kubeadm::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 . Open a terminal and run the following:
 +
 [source,bash,subs=attributes+]
@@ -379,7 +388,7 @@ export KUBERNETES_VERSION={kubernetes-version}
 
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** to ensure there are no tokens. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here]. 
@@ -391,17 +400,19 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl create -f cluster1.yaml 
 ----
-+
+
 . Deploy CNI
 +
 > Once cluster is created a CNI is required for Nodes to become ready. You can refere to Cluster API documentation for example CNI installation https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution[here].
+--
 
 vSphere RKE2::
 +
+--
 Before creating a vSphere+RKE2 workload cluster, it is required to have a VM template with the necessary RKE2 binaries and dependencies. The template should already include RKE2 binaries if operating in an air-gapped environment, following the https://docs.rke2.io/install/airgap#tarball-method[tarball method]. You can find additional configuration details in the https://github.com/rancher/cluster-api-provider-rke2/tree/main/samples/vmware[CAPRKE2 repository].
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -424,18 +435,18 @@ export VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."
 export CPI_IMAGE_K8S_VERSION: "v1.31.0"
 export KUBERNETES_VERSION={kubernetes-version}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-rke2.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -443,15 +454,17 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
+--
 
 vSphere Kubeadm::
 +
+--
 Before creating a vSphere+kubeadm workload cluster, it is required to have a VM template with the necessary kubeadm binaries and dependencies. The template should already include kubeadm, kubelet, and kubectl if operating in an air-gapped environment, following the https://github.com/kubernetes-sigs/image-builder[image-builder project]. You can find additional configuration details in the https://github.com/kubernetes-sigs/cluster-api-provider-vsphere[CAPV repository].
-+
+
 A list of published machine images (OVAs) is available https://github.com/kubernetes-sigs/image-builder#kubernetes-versions-with-published-ovas[here].
-+
+
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -474,18 +487,18 @@ export VSPHERE_SSH_AUTHORIZED_KEY: "ssh-rsa AAAAB3N..."
 export CPI_IMAGE_K8S_VERSION: "v1.31.0"
 export KUBERNETES_VERSION={kubernetes-version}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -493,11 +506,13 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
+--
 
 AWS EKS::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -505,18 +520,18 @@ export NAMESPACE={namespace}
 export WORKER_MACHINE_COUNT={worker-machine-count}
 export KUBERNETES_VERSION={kubernetes-version}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/aws-eks-mmp.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -524,11 +539,13 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
+--
 
 GCP GKE::
 +
+--
 To generate the YAML for the cluster, do the following:
-+
+
 [source,bash,subs=attributes+]
 ----
 export CLUSTER_NAME={cluster-name}
@@ -538,18 +555,18 @@ export GCP_REGION=us-east4
 export GCP_NETWORK_NAME=default
 export WORKER_MACHINE_COUNT={worker-machine-count}
 ----
-+
+
 . Open a terminal and run the following:
 +
 [source,bash]
 ----
 curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/gcp-gke.yaml | envsubst > cluster1.yaml
 ----
-+
+
 . View **cluster1.yaml** and examine the resulting YAML file. You can make any changes you want as well.
 +
 > The Cluster API quickstart guide contains more detail. Read the steps related to this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers[here].
-+
+
 . Create the cluster using kubectl
 +
 [source,bash]
@@ -557,7 +574,7 @@ curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e
 kubectl create namespace ${NAMESPACE}
 kubectl apply -f cluster1.yaml
 ----
-
+--
 ======
 
 [TIP]

--- a/versions/v0.18/modules/en/pages/user/fleet.adoc
+++ b/versions/v0.18/modules/en/pages/user/fleet.adoc
@@ -27,7 +27,8 @@ There are 2 options to provide the configuration. The first is using the Rancher
 [tabs]
 ======
 Using the Rancher Manager UI::
-
++
+--
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the menu.
 . Select *fleet-local* as the namespace from the top right.
@@ -43,9 +44,11 @@ Using the Rancher Manager UI::
 . Click *Create*.
 . Click on the *clusters* name.
 . Watch the resources become ready.
+--
 
 Manually using kubectl::
-
++
+--
 . Get the *HTTPS* clone URL from your git repo.
 . Create a new file called *repo.yaml*.
 . Add the following contents to the new file:
@@ -64,14 +67,14 @@ spec:
     - /classes
   targets: []
 ----
-+
+
 . Apply the file to the Rancher Manager cluster using *kubectl*:
 +
 [source,bash]
 ----
 kubectl apply -f repo.yaml
 ----
-+
+
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the side bar.
 . Select *fleet-local* as the namespace from the top right.
@@ -80,6 +83,7 @@ kubectl apply -f repo.yaml
 . Watch the resources become ready.
 . Select *Cluster Management* from the menu.
 . Check that your cluster has been imported.
+--
 ======
 
 === Import Cluster Definitions
@@ -89,7 +93,8 @@ Now that the classes have been imported, it's possible to use them with cluster 
 [tabs]
 ======
 Using the Rancher Manager UI::
-
++
+--
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the menu.
 . Select *fleet-local* as the namespace from the top right.
@@ -107,9 +112,11 @@ Using the Rancher Manager UI::
 . Watch the resources become ready.
 . Select *Cluster Management* from the menu.
 . Check that your cluster has been imported.
+--
 
 Manually using kubectl::
-
++
+--
 . Get the *HTTPS* clone URL from your git repo.
 . Create a new file called *repo.yaml*.
 . Add the following contents to the new file:
@@ -128,14 +135,14 @@ spec:
     - /clusters
   targets: []
 ----
-+
+
 . Apply the file to the Rancher Manager cluster using *kubectl*:
 +
 [source,bash]
 ----
 kubectl apply -f repo.yaml
 ----
-+
+
 . Go to Rancher Manager.
 . Select *Continuous Delivery* from the side bar.
 . Select *fleet-local* as the namespace from the top right.
@@ -144,4 +151,5 @@ kubectl apply -f repo.yaml
 . Watch the resources become ready.
 . Select *Cluster Management* from the menu.
 . Check that your cluster has been imported.
+--
 ======


### PR DESCRIPTION
Syncing the Community PR's for Turtles product, syncing /next, v0.18 and one v0.17 nav update. Additionally added the DSC style repo and updated the local playbook with `branches: head` for better testing purposes. Will cut the v0.19 release after this PR is merged.

Reference PR's and commits:
https://github.com/rancher/turtles-docs/pull/271 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/272 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/274 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/276 - https://github.com/rancher/turtles-product-docs/pull/42/commits/64f1aef5db74042f4dbd294b408eae09c80561a7
https://github.com/rancher/turtles-docs/pull/277 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/285 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/279 - https://github.com/rancher/turtles-product-docs/pull/42/commits/5d16940b7dacd2dfc2103443b3fec8a25697a22d, https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/280 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/281 - https://github.com/rancher/turtles-product-docs/pull/42/commits/6f6e9859d3a604e3b49ede70f500a1a1b27dbf74
https://github.com/rancher/turtles-docs/pull/288 - https://github.com/rancher/turtles-product-docs/pull/42/commits/d3487e76fe4a18fc69e32bf3969bddd29c217fdc