### PR TITLE
Use xref for cross references

### DIFF
--- a/versions/next/modules/en/pages/changelogs/index.adoc
+++ b/versions/next/modules/en/pages/changelogs/index.adoc
@@ -1,45 +1,45 @@
 = Release Notes
 
-* link:changelogs/v0.19.0.html[v0.19.0 (latest)]
+* xref:changelogs/changelogs/v0.19.0.adoc[v0.19.0 (latest)]
 
-* link:changelogs/v0.18.0.html[v0.18.0]
+* xref:changelogs/changelogs/v0.18.0.adoc[v0.18.0]
 
-* link:changelogs/v0.17.0.html[v0.17.0]
+* xref:changelogs/changelogs/v0.17.0.adoc[v0.17.0]
 
-* link:changelogs/v0.16.0.html[v0.16.0]
+* xref:changelogs/changelogs/v0.16.0.adoc[v0.16.0]
 
-* link:changelogs/v0.15.0.html[v0.15.0]
+* xref:changelogs/changelogs/v0.15.0.adoc[v0.15.0]
 
-* link:changelogs/v0.14.1.html[v0.14.1]
+* xref:changelogs/changelogs/v0.14.1.adoc[v0.14.1]
 
-* link:changelogs/v0.14.0.html[v0.14.0]
+* xref:changelogs/changelogs/v0.14.0.adoc[v0.14.0]
 
-* link:changelogs/v0.13.0.html[v0.13.0]
+* xref:changelogs/changelogs/v0.13.0.adoc[v0.13.0]
 
-* link:changelogs/v0.12.0.html[v0.12.0]
+* xref:changelogs/changelogs/v0.12.0.adoc[v0.12.0]
 
-* link:changelogs/v0.11.0.html[v0.11.0]
+* xref:changelogs/changelogs/v0.11.0.adoc[v0.11.0]
 
-* link:changelogs/v0.10.0.html[v0.10.0]
+* xref:changelogs/changelogs/v0.10.0.adoc[v0.10.0]
 
-* link:changelogs/v0.9.1.html[v0.9.1]
+* xref:changelogs/changelogs/v0.9.1.adoc[v0.9.1]
 
-* link:changelogs/v0.9.0.html[v0.9.0]
+* xref:changelogs/changelogs/v0.9.0.adoc[v0.9.0]
 
-* link:changelogs/v0.8.0.html[v0.8.0]
+* xref:changelogs/changelogs/v0.8.0.adoc[v0.8.0]
 
-* link:changelogs/v0.7.0.html[v0.7.0]
+* xref:changelogs/changelogs/v0.7.0.adoc[v0.7.0]
 
-* link:changelogs/v0.6.0.html[v0.6.0]
+* xref:changelogs/changelogs/v0.6.0.adoc[v0.6.0]
 
-* link:changelogs/v0.5.0.html[v0.5.0]
+* xref:changelogs/changelogs/v0.5.0.adoc[v0.5.0]
 
-* link:changelogs/v0.4.1.html[v0.4.1]
+* xref:changelogs/changelogs/v0.4.1.adoc[v0.4.1]
 
-* link:changelogs/v0.4.0.html[v0.4.0]
+* xref:changelogs/changelogs/v0.4.0.adoc[v0.4.0]
 
-* link:changelogs/v0.3.0.html[v0.3.0]
+* xref:changelogs/changelogs/v0.3.0.adoc[v0.3.0]
 
-* link:changelogs/v0.2.0.html[v0.2.0]
+* xref:changelogs/changelogs/v0.2.0.adoc[v0.2.0]
 
-* link:changelogs/v0.1.0.html[v0.1.0]
+* xref:changelogs/changelogs/v0.1.0.adoc[v0.1.0]

--- a/versions/v0.16/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/index.adoc
@@ -1,41 +1,41 @@
 = Release Notes
 
 
-* link:changelogs/v0.16.0.html[v0.16.0 (latest)]
+* xref:changelogs/changelogs/v0.16.0.adoc[v0.16.0 (latest)]
 
-* link:changelogs/v0.15.0.html[v0.15.0 ]
+* xref:changelogs/changelogs/v0.15.0.adoc[v0.15.0 ]
 
-* link:changelogs/v0.14.1.html[v0.14.1 ]
+* xref:changelogs/changelogs/v0.14.1.adoc[v0.14.1 ]
 
-* link:changelogs/v0.14.0.html[v0.14.0 ]
+* xref:changelogs/changelogs/v0.14.0.adoc[v0.14.0 ]
 
-* link:changelogs/v0.13.0.html[v0.13.0 ]
+* xref:changelogs/changelogs/v0.13.0.adoc[v0.13.0 ]
 
-* link:changelogs/v0.12.0.html[v0.12.0 ]
+* xref:changelogs/changelogs/v0.12.0.adoc[v0.12.0 ]
 
-* link:changelogs/v0.11.0.html[v0.11.0 ]
+* xref:changelogs/changelogs/v0.11.0.adoc[v0.11.0 ]
 
-* link:changelogs/v0.10.0.html[v0.10.0 ]
+* xref:changelogs/changelogs/v0.10.0.adoc[v0.10.0 ]
 
-* link:changelogs/v0.9.1.html[v0.9.1 ]
+* xref:changelogs/changelogs/v0.9.1.adoc[v0.9.1 ]
 
-* link:changelogs/v0.9.0.html[v0.9.0 ]
+* xref:changelogs/changelogs/v0.9.0.adoc[v0.9.0 ]
 
-* link:changelogs/v0.8.0.html[v0.8.0 ]
+* xref:changelogs/changelogs/v0.8.0.adoc[v0.8.0 ]
 
-* link:changelogs/v0.7.0.html[v0.7.0 ]
+* xref:changelogs/changelogs/v0.7.0.adoc[v0.7.0 ]
 
-* link:changelogs/v0.6.0.html[v0.6.0 ]
+* xref:changelogs/changelogs/v0.6.0.adoc[v0.6.0 ]
 
-* link:changelogs/v0.5.0.html[v0.5.0 ]
+* xref:changelogs/changelogs/v0.5.0.adoc[v0.5.0 ]
 
-* link:changelogs/v0.4.1.html[v0.4.1 ]
+* xref:changelogs/changelogs/v0.4.1.adoc[v0.4.1 ]
 
-* link:changelogs/v0.4.0.html[v0.4.0 ]
+* xref:changelogs/changelogs/v0.4.0.adoc[v0.4.0 ]
 
-* link:changelogs/v0.3.0.html[v0.3.0 ]
+* xref:changelogs/changelogs/v0.3.0.adoc[v0.3.0 ]
 
-* link:changelogs/v0.2.0.html[v0.2.0 ]
+* xref:changelogs/changelogs/v0.2.0.adoc[v0.2.0 ]
 
-* link:changelogs/v0.1.0.html[v0.1.0 ]
+* xref:changelogs/changelogs/v0.1.0.adoc[v0.1.0 ]
 

--- a/versions/v0.17/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/index.adoc
@@ -1,43 +1,43 @@
 = Release Notes
 
 
-* link:changelogs/v0.17.0.html[v0.17.0 (latest)]
+* xref:changelogs/changelogs/v0.17.0.adoc[v0.17.0 (latest)]
 
-* link:changelogs/v0.16.0.html[v0.16.0 ]
+* xref:changelogs/changelogs/v0.16.0.adoc[v0.16.0 ]
 
-* link:changelogs/v0.15.0.html[v0.15.0 ]
+* xref:changelogs/changelogs/v0.15.0.adoc[v0.15.0 ]
 
-* link:changelogs/v0.14.1.html[v0.14.1 ]
+* xref:changelogs/changelogs/v0.14.1.adoc[v0.14.1 ]
 
-* link:changelogs/v0.14.0.html[v0.14.0 ]
+* xref:changelogs/changelogs/v0.14.0.adoc[v0.14.0 ]
 
-* link:changelogs/v0.13.0.html[v0.13.0 ]
+* xref:changelogs/changelogs/v0.13.0.adoc[v0.13.0 ]
 
-* link:changelogs/v0.12.0.html[v0.12.0 ]
+* xref:changelogs/changelogs/v0.12.0.adoc[v0.12.0 ]
 
-* link:changelogs/v0.11.0.html[v0.11.0 ]
+* xref:changelogs/changelogs/v0.11.0.adoc[v0.11.0 ]
 
-* link:changelogs/v0.10.0.html[v0.10.0 ]
+* xref:changelogs/changelogs/v0.10.0.adoc[v0.10.0 ]
 
-* link:changelogs/v0.9.1.html[v0.9.1 ]
+* xref:changelogs/changelogs/v0.9.1.adoc[v0.9.1 ]
 
-* link:changelogs/v0.9.0.html[v0.9.0 ]
+* xref:changelogs/changelogs/v0.9.0.adoc[v0.9.0 ]
 
-* link:changelogs/v0.8.0.html[v0.8.0 ]
+* xref:changelogs/changelogs/v0.8.0.adoc[v0.8.0 ]
 
-* link:changelogs/v0.7.0.html[v0.7.0 ]
+* xref:changelogs/changelogs/v0.7.0.adoc[v0.7.0 ]
 
-* link:changelogs/v0.6.0.html[v0.6.0 ]
+* xref:changelogs/changelogs/v0.6.0.adoc[v0.6.0 ]
 
-* link:changelogs/v0.5.0.html[v0.5.0 ]
+* xref:changelogs/changelogs/v0.5.0.adoc[v0.5.0 ]
 
-* link:changelogs/v0.4.1.html[v0.4.1 ]
+* xref:changelogs/changelogs/v0.4.1.adoc[v0.4.1 ]
 
-* link:changelogs/v0.4.0.html[v0.4.0 ]
+* xref:changelogs/changelogs/v0.4.0.adoc[v0.4.0 ]
 
-* link:changelogs/v0.3.0.html[v0.3.0 ]
+* xref:changelogs/changelogs/v0.3.0.adoc[v0.3.0 ]
 
-* link:changelogs/v0.2.0.html[v0.2.0 ]
+* xref:changelogs/changelogs/v0.2.0.adoc[v0.2.0 ]
 
-* link:changelogs/v0.1.0.html[v0.1.0 ]
+* xref:changelogs/changelogs/v0.1.0.adoc[v0.1.0 ]
 

--- a/versions/v0.18/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/index.adoc
@@ -1,45 +1,45 @@
 = Release Notes
 
 
-* link:changelogs/v0.18.0.html[v0.18.0 (latest)]
+* xref:changelogs/changelogs/v0.18.0.adoc[v0.18.0 (latest)]
 
-* link:changelogs/v0.17.0.html[v0.17.0 ]
+* xref:changelogs/changelogs/v0.17.0.adoc[v0.17.0 ]
 
-* link:changelogs/v0.16.0.html[v0.16.0 ]
+* xref:changelogs/changelogs/v0.16.0.adoc[v0.16.0 ]
 
-* link:changelogs/v0.15.0.html[v0.15.0 ]
+* xref:changelogs/changelogs/v0.15.0.adoc[v0.15.0 ]
 
-* link:changelogs/v0.14.1.html[v0.14.1 ]
+* xref:changelogs/changelogs/v0.14.1.adoc[v0.14.1 ]
 
-* link:changelogs/v0.14.0.html[v0.14.0 ]
+* xref:changelogs/changelogs/v0.14.0.adoc[v0.14.0 ]
 
-* link:changelogs/v0.13.0.html[v0.13.0 ]
+* xref:changelogs/changelogs/v0.13.0.adoc[v0.13.0 ]
 
-* link:changelogs/v0.12.0.html[v0.12.0 ]
+* xref:changelogs/changelogs/v0.12.0.adoc[v0.12.0 ]
 
-* link:changelogs/v0.11.0.html[v0.11.0 ]
+* xref:changelogs/changelogs/v0.11.0.adoc[v0.11.0 ]
 
-* link:changelogs/v0.10.0.html[v0.10.0 ]
+* xref:changelogs/changelogs/v0.10.0.adoc[v0.10.0 ]
 
-* link:changelogs/v0.9.1.html[v0.9.1 ]
+* xref:changelogs/changelogs/v0.9.1.adoc[v0.9.1 ]
 
-* link:changelogs/v0.9.0.html[v0.9.0 ]
+* xref:changelogs/changelogs/v0.9.0.adoc[v0.9.0 ]
 
-* link:changelogs/v0.8.0.html[v0.8.0 ]
+* xref:changelogs/changelogs/v0.8.0.adoc[v0.8.0 ]
 
-* link:changelogs/v0.7.0.html[v0.7.0 ]
+* xref:changelogs/changelogs/v0.7.0.adoc[v0.7.0 ]
 
-* link:changelogs/v0.6.0.html[v0.6.0 ]
+* xref:changelogs/changelogs/v0.6.0.adoc[v0.6.0 ]
 
-* link:changelogs/v0.5.0.html[v0.5.0 ]
+* xref:changelogs/changelogs/v0.5.0.adoc[v0.5.0 ]
 
-* link:changelogs/v0.4.1.html[v0.4.1 ]
+* xref:changelogs/changelogs/v0.4.1.adoc[v0.4.1 ]
 
-* link:changelogs/v0.4.0.html[v0.4.0 ]
+* xref:changelogs/changelogs/v0.4.0.adoc[v0.4.0 ]
 
-* link:changelogs/v0.3.0.html[v0.3.0 ]
+* xref:changelogs/changelogs/v0.3.0.adoc[v0.3.0 ]
 
-* link:changelogs/v0.2.0.html[v0.2.0 ]
+* xref:changelogs/changelogs/v0.2.0.adoc[v0.2.0 ]
 
-* link:changelogs/v0.1.0.html[v0.1.0 ]
+* xref:changelogs/changelogs/v0.1.0.adoc[v0.1.0 ]
 

--- a/versions/v0.19/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/index.adoc
@@ -1,45 +1,45 @@
 = Release Notes
 
-* link:changelogs/v0.19.0.html[v0.19.0 (latest)]
+* xref:changelogs/changelogs/v0.19.0.adoc[v0.19.0 (latest)]
 
-* link:changelogs/v0.18.0.html[v0.18.0]
+* xref:changelogs/changelogs/v0.18.0.adoc[v0.18.0]
 
-* link:changelogs/v0.17.0.html[v0.17.0]
+* xref:changelogs/changelogs/v0.17.0.adoc[v0.17.0]
 
-* link:changelogs/v0.16.0.html[v0.16.0]
+* xref:changelogs/changelogs/v0.16.0.adoc[v0.16.0]
 
-* link:changelogs/v0.15.0.html[v0.15.0]
+* xref:changelogs/changelogs/v0.15.0.adoc[v0.15.0]
 
-* link:changelogs/v0.14.1.html[v0.14.1]
+* xref:changelogs/changelogs/v0.14.1.adoc[v0.14.1]
 
-* link:changelogs/v0.14.0.html[v0.14.0]
+* xref:changelogs/changelogs/v0.14.0.adoc[v0.14.0]
 
-* link:changelogs/v0.13.0.html[v0.13.0]
+* xref:changelogs/changelogs/v0.13.0.adoc[v0.13.0]
 
-* link:changelogs/v0.12.0.html[v0.12.0]
+* xref:changelogs/changelogs/v0.12.0.adoc[v0.12.0]
 
-* link:changelogs/v0.11.0.html[v0.11.0]
+* xref:changelogs/changelogs/v0.11.0.adoc[v0.11.0]
 
-* link:changelogs/v0.10.0.html[v0.10.0]
+* xref:changelogs/changelogs/v0.10.0.adoc[v0.10.0]
 
-* link:changelogs/v0.9.1.html[v0.9.1]
+* xref:changelogs/changelogs/v0.9.1.adoc[v0.9.1]
 
-* link:changelogs/v0.9.0.html[v0.9.0]
+* xref:changelogs/changelogs/v0.9.0.adoc[v0.9.0]
 
-* link:changelogs/v0.8.0.html[v0.8.0]
+* xref:changelogs/changelogs/v0.8.0.adoc[v0.8.0]
 
-* link:changelogs/v0.7.0.html[v0.7.0]
+* xref:changelogs/changelogs/v0.7.0.adoc[v0.7.0]
 
-* link:changelogs/v0.6.0.html[v0.6.0]
+* xref:changelogs/changelogs/v0.6.0.adoc[v0.6.0]
 
-* link:changelogs/v0.5.0.html[v0.5.0]
+* xref:changelogs/changelogs/v0.5.0.adoc[v0.5.0]
 
-* link:changelogs/v0.4.1.html[v0.4.1]
+* xref:changelogs/changelogs/v0.4.1.adoc[v0.4.1]
 
-* link:changelogs/v0.4.0.html[v0.4.0]
+* xref:changelogs/changelogs/v0.4.0.adoc[v0.4.0]
 
-* link:changelogs/v0.3.0.html[v0.3.0]
+* xref:changelogs/changelogs/v0.3.0.adoc[v0.3.0]
 
-* link:changelogs/v0.2.0.html[v0.2.0]
+* xref:changelogs/changelogs/v0.2.0.adoc[v0.2.0]
 
-* link:changelogs/v0.1.0.html[v0.1.0]
+* xref:changelogs/changelogs/v0.1.0.adoc[v0.1.0]


### PR DESCRIPTION
The referenced pages currently use the `link` macro for cross references. Using `link` instead of `xref` also means the targets aren't validated by Antora at build time.