### PR TITLE
Updating GH Pages - supplemental_files path

### DIFF
--- a/turtles-local-playbook.yml
+++ b/turtles-local-playbook.yml
@@ -14,7 +14,7 @@ ui:
   bundle:
     url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true
     snapshot: true
-  supplemental_files: ./dsc-style-bundle/supplemental-files/rancher
+  supplemental_files: /home/runner/work/turtles-product-docs/turtles-product-docs/dsc-style-bundle/supplemental-files/rancher
 
 asciidoc:
   attributes:


### PR DESCRIPTION
Updating the supplemental_files path with what is specified during site generation for the GitHub pages. Currently the action is failing on the step referenced below, stating `[22:32:30.904] FATAL (antora): Specified ui.supplemental_files directory does not exist: ./dsc-style-bundle/supplemental-files/rancher (resolved to /home/runner/work/turtles-product-docs/turtles-product-docs/dsc-style-bundle/supplemental-files/rancher)`.

https://github.com/rancher/turtles-product-docs/actions/runs/17658982787/job/50188391358#step:6:14