### PR TITLE
Update revdate so SU notices.

### DIFF
--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
@@ -1,5 +1,5 @@
 = "v0.21.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-06-30 13:10:47 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
@@ -1,5 +1,5 @@
 = "v0.22.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-07-29 13:17:49 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
@@ -1,5 +1,5 @@
 = "v0.23.0"
-:revdate: 2025-08-25
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-08-25 12:13:30 +0000 UTC"

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.24.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.24.0.adoc
@@ -1,5 +1,5 @@
 = "v0.24.0"
-:revdate: 2025-09-16
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-09-15 10:40:28 +0000 UTC"

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/latest/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/latest/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
@@ -1,5 +1,5 @@
 = "v0.21.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-06-30 13:10:47 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
@@ -1,5 +1,5 @@
 = "v0.22.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-07-29 13:17:49 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
@@ -1,5 +1,5 @@
 = "v0.23.0"
-:revdate: 2025-08-25
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-08-25 12:13:30 +0000 UTC"

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.24.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.24.0.adoc
@@ -1,5 +1,5 @@
 = "v0.24.0"
-:revdate: 2025-09-16
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-09-15 10:40:28 +0000 UTC"

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/next/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/next/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.16/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.17/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.18/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.19/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.20/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
@@ -1,5 +1,5 @@
 = "v0.21.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-06-30 13:10:47 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.21/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
@@ -1,5 +1,5 @@
 = "v0.21.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-06-30 13:10:47 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
@@ -1,5 +1,5 @@
 = "v0.22.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-07-29 13:17:49 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.22/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
@@ -1,5 +1,5 @@
 = "v0.21.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-06-30 13:10:47 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
@@ -1,5 +1,5 @@
 = "v0.22.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-07-29 13:17:49 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
@@ -1,5 +1,5 @@
 = "v0.23.0"
-:revdate: 2025-08-25
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-08-25 12:13:30 +0000 UTC"

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.23/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.1.0.adoc
@@ -1,5 +1,5 @@
 = "v0.1.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-03 10:02:01 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.10.0.adoc
@@ -1,5 +1,5 @@
 = "v0.10.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-29 10:04:39 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.11.0.adoc
@@ -1,5 +1,5 @@
 = "v0.11.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-08-22 14:23:44 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.12.0.adoc
@@ -1,5 +1,5 @@
 = "v0.12.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-09-26 09:53:01 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.13.0.adoc
@@ -1,5 +1,5 @@
 = "v0.13.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-10-28 11:45:00 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.14.0.adoc
@@ -1,5 +1,5 @@
 = "v0.14.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-02 20:20:03 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.14.1.adoc
@@ -1,5 +1,5 @@
 = "v0.14.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-03 09:34:26 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.15.0.adoc
@@ -1,5 +1,5 @@
 = "v0.15.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-12-19 10:32:58 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.16.0.adoc
@@ -1,5 +1,5 @@
 = "v0.16.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-01-30 10:15:15 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.17.0.adoc
@@ -1,5 +1,5 @@
 = "v0.17.0"
-:revdate: 2025-02-27
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-02-27 10:39:19 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.18.0.adoc
@@ -1,5 +1,5 @@
 = "v0.18.0"
-:revdate: 2025-03-31
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-03-31 12:14:42 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.19.0.adoc
@@ -1,5 +1,5 @@
 = "v0.19.0"
-:revdate: 2025-05-06
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-04-29 09:14:28 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.2.0.adoc
@@ -1,5 +1,5 @@
 = "v0.2.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-10-23 14:56:55 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.20.0.adoc
@@ -1,5 +1,5 @@
 = "v0.20.0"
-:revdate: 2025-05-30
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-05-29 09:13:48 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.21.0.adoc
@@ -1,5 +1,5 @@
 = "v0.21.0"
-:revdate: 2025-07-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-06-30 13:10:47 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.22.0.adoc
@@ -1,5 +1,5 @@
 = "v0.22.0"
-:revdate: 2025-08-01
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2025-07-29 13:17:49 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.23.0.adoc
@@ -1,5 +1,5 @@
 = "v0.23.0"
-:revdate: 2025-08-25
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-08-25 12:13:30 +0000 UTC"

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.24.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.24.0.adoc
@@ -1,5 +1,5 @@
 = "v0.24.0"
-:revdate: 2025-09-16
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == "2025-09-15 10:40:28 +0000 UTC"

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.3.0.adoc
@@ -1,5 +1,5 @@
 = "v0.3.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2023-11-20 12:26:12 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.4.0.adoc
@@ -1,5 +1,5 @@
 = "v0.4.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-09 11:39:06 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.4.1.adoc
@@ -1,5 +1,5 @@
 = "v0.4.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-01-17 17:18:48 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.5.0.adoc
@@ -1,5 +1,5 @@
 = "v0.5.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-02-15 11:32:39 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.6.0.adoc
@@ -1,5 +1,5 @@
 = "v0.6.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-04-04 12:21:10 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.7.0.adoc
@@ -1,5 +1,5 @@
 = "v0.7.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-02 14:21:37 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.8.0.adoc
@@ -1,5 +1,5 @@
 = "v0.8.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-05-30 12:11:48 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.9.0.adoc
@@ -1,5 +1,5 @@
 = "v0.9.0"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-06-28 10:54:06 +0000 UTC"
 

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.9.1.adoc
@@ -1,5 +1,5 @@
 = "v0.9.1"
-:revdate: 2025-02-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 == "2024-07-18 13:15:25 +0000 UTC"
 


### PR DESCRIPTION
Update the revdate for those files that had heading levels changed to avoid untitled HTML docs occasionally occurring. Need a revdate bump as well, so that SU notices. Probably.