### PR TITLE
Set site.url so canonical URLs are generated

### DIFF
--- a/turtles-dev-community-playbook.yml
+++ b/turtles-dev-community-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Rancher Turtles
-  url: /
+  url: https://turtles.docs.rancher.com
   start_page: v0.26@turtles:en:index.adoc
 
 content:

--- a/turtles-local-community-playbook.yml
+++ b/turtles-local-community-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Rancher Turtles
-  url: /
+  url: https://turtles.docs.rancher.com
   start_page: v0.25@turtles:en:index.adoc
 
 urls:

--- a/turtles-remote-community-playbook.yml
+++ b/turtles-remote-community-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Rancher Turtles
-  url: /
+  url: https://turtles.docs.rancher.com
   start_page: v0.25@turtles:en:index.adoc
 
 content:


### PR DESCRIPTION
Absent canonical URLs impact our SEO and could lead to search results pointing to older versions.