### PR TITLE
Adding Extension - unpublish-unlisted-pages.js

### DIFF
--- a/turtles-local-community-playbook.yml
+++ b/turtles-local-community-playbook.yml
@@ -34,6 +34,8 @@ antora:
   - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
     attributefile: ./product-docs-common/global-attributes.yml
     enabled: true
+  - require: ./product-docs-common/extensions/unpublish-unlisted-pages/unpublish-unlisted-pages.js
+    component: 'turtles'
 
 output:
   dir: build/site-community


### PR DESCRIPTION
Adding extension in playbook file used in publishing Community site. The extension removes unlisted pages from being published.