### PR TITLE
Removing Draft Preview - Community Site

### DIFF
--- a/turtles-local-community-playbook.yml
+++ b/turtles-local-community-playbook.yml
@@ -21,7 +21,6 @@ ui:
 
 asciidoc:
   attributes:
-    page-draft-preview-only: 'true'
     page-pagination: ''
     page-toclevels: 4@
     tabs-sync-option: ''


### PR DESCRIPTION
Removing the draft preview banner from Community docs build as the source repository for Community now points to the GH pages in this repo.