### PR TITLE
update aks provisioning guide

### DIFF
--- a/versions/v0.26/modules/en/pages/user/clusterclass.adoc
+++ b/versions/v0.26/modules/en/pages/user/clusterclass.adoc
@@ -163,6 +163,13 @@ spec:
 
 * Identity Setup
 +
+[WARNING]
+.Authentication for AKS cluster provisioning
+====
+If you are deploying a managed cluster on **AKS**, you can skip the **Identity Setup** step and jump to xref:#_create_a_cluster_from_a_clusterclass[Create a Cluster from a ClusterClass].
+Instead of using `AzureClusterIdentity`, you will create a `Secret` with the Service Principal credentials for the Azure Service Operator to use when applying the cluster manifest.
+====
++
 In this example we are going to use an `AzureClusterIdentity` to provision Azure Clusters.
 A Secret containing the Service Principal credentials needs to be created first, to be referenced by the `AzureClusterIdentity` resource.
 Note that the `AzureClusterIdentity` is a namespaced resource and it needs to be created in the same namespace as the Cluster.
@@ -488,15 +495,15 @@ Azure AKS::
 =======
 CLI::
 +
-An Azure RKE2 ClusterClass and associated applications can be applied using the examples tool:
+An Azure AKS ClusterClass can be applied using the examples tool:
 +
 [source,bash, subs="attributes"]
 ----
-go run github.com/rancher/turtles/examples@{turtles_version} -r azure-rke2 | kubectl apply -f -
+go run github.com/rancher/turtles/examples@{turtles_version} -r azure-aks | kubectl apply -f -
 ----
 kubectl::
 +
-* Alternatively, you can apply the Azure RKE2 ClusterClass directly using kubectl:
+* Alternatively, you can apply the Azure AKS ClusterClass directly using kubectl:
 +
 [source,bash, subs="attributes"]
 ----
@@ -506,11 +513,28 @@ kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/tags/{tu
 
 * Create the Azure AKS Cluster from the example ClusterClass.
 +
+The Azure AKS `ClusterClass` that the `Cluster` is created from uses the `AzureASOManagedCluster`, `AzureASOManagedControlPlane` and `AzureASOManagedMachinePool` resources that are managed by Azure Service Operator.
+For this reason you won't use a `AzureClusterIdentity` as you would for a self-managed Azure cluster (e.g. Azure with RKE2). Instead a `Secret` is created with the Service Principal credentials in the same namespace as the `Cluster`.
+Note that the `Secret` definition is embedded in the `Cluster` manifest for simplicity, but it can be created beforehand as well.
++
+You can refer to the https://azure.github.io/azure-service-operator/guide/authentication/[Azure Service Operator documentation] for more information on this method of authentication.
++
 Note that some variables are left to the user to substitute.
 +
 [source,yaml]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aks-credentials
+stringData:
+  AZURE_SUBSCRIPTION_ID: <AZURE_SUBSCRIPTION_ID>
+  AZURE_TENANT_ID: <AZURE_TENANT_ID>
+  AZURE_CLIENT_ID: <AZURE_CLIENT_ID>
+  AZURE_CLIENT_SECRET: <AZURE_CLIENT_SECRET>
+type: Opaque
+---
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   labels:
@@ -524,15 +548,13 @@ spec:
   topology:
     class: azure-aks-example
     variables:
-    - name: subscriptionID
-      value: <AZURE_SUBSCRIPTION_ID>
     - name: location
       value: <AZURE_LOCATION>
     - name: resourceGroup
       value: <AZURE_RESOURCE_GROUP>
-    - name: azureClusterIdentityName
-      value: cluster-identity
-    version: v1.31.4
+    - name: asoCredentialSecretName
+      value: aks-credentials
+    version: v1.34.2
     workers:
       machinePools:
       - class: default-system


### PR DESCRIPTION
# Description

Adapt AKS cluster provisioning guide to new sample `ClusterClass` using `AzureASOManagedCluster` and other ASO-specific resources after deprecation of `AzureManagedCluster` and related.

Since authentication for AKS (only) has changed and doesn't require a `AzureClusterIdentity` anymore, a new `Warning` is added on `Identity Setup`. Users are asked to jump to cluster creation and skip this step for AKS:

<img width="927" height="409" alt="image" src="https://github.com/user-attachments/assets/1b834a77-43d2-4a6b-904a-1a643284a204" />

The secret for authenticating with Azure Service Operator is now embedded in the cluster manifest and created in the same namespace as the CAPI cluster resource:

<img width="922" height="699" alt="image" src="https://github.com/user-attachments/assets/0d700d47-01ad-4579-af8e-174247ed4ad8" />

Fixes #147 