### PR TITLE
Document certified providers pinned versions

### DIFF
--- a/.github/scripts/sync-certified-providers-version.sh
+++ b/.github/scripts/sync-certified-providers-version.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Copyright © 2026 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to update all certified providers version for all docs releases.
+
+set -e
+
+cd $(dirname "$0")/../../versions
+versions=`find ./ -maxdepth 1 -type d | grep "v." | sed "s|./||g"`
+
+for version in $versions
+do
+  printf "\n### Syncing version: $version ###\n"
+  url="https://raw.githubusercontent.com/rancher/turtles/refs/heads/release/$version/internal/controllers/clusterctl/config-prime.yaml"
+  if ! curl --output /dev/null --silent --head --fail "$url"; then
+    echo "Config not found. This version is not supported. Aborting."
+    continue
+  fi
+
+  config_file=`curl https://raw.githubusercontent.com/rancher/turtles/refs/heads/release/$version/internal/controllers/clusterctl/config-prime.yaml`
+  clusterctl_config=`echo "$config_file" | yq '.data["clusterctl.yaml"]'`
+
+  antora_file_path="./$version/antora-yml/antora-product.yml"
+
+  aws_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "aws" and .type == "InfrastructureProvider").url' | cut -d'/' -f7`
+  echo "Found CAPA version: $aws_version"
+  aws_version=$aws_version yq -i '.asciidoc.attributes.aws_version=strenv(aws_version)' $antora_file_path
+
+  azure_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "azure" and .type == "InfrastructureProvider").url' | cut -d'/' -f7`
+  echo "Found CAPZ version: $azure_version"
+  azure_version=$azure_version yq -i '.asciidoc.attributes.azure_version=strenv(azure_version)' $antora_file_path
+
+  gcp_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "gcp" and .type == "InfrastructureProvider").url' | cut -d'/' -f7`
+  echo "Found CAPG version: $gcp_version"
+  gcp_version=$gcp_version yq -i '.asciidoc.attributes.gcp_version=strenv(gcp_version)' $antora_file_path
+
+  vsphere_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "vsphere" and .type == "InfrastructureProvider").url' | cut -d'/' -f7`
+  echo "Found CAPV version: $vsphere_version"
+  vsphere_version=$vsphere_version yq -i '.asciidoc.attributes.vsphere_version=strenv(vsphere_version)' $antora_file_path
+
+  docker_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "docker" and .type == "InfrastructureProvider").url' | cut -d'/' -f7`
+  echo "Found CAPD version: $docker_version"
+  docker_version=$docker_version yq -i '.asciidoc.attributes.docker_version=strenv(docker_version)' $antora_file_path
+
+  kubeadm_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "kubeadm" and .type == "ControlPlaneProvider").url' | cut -d'/' -f7`
+  echo "Found Kubeadm version: $kubeadm_version"
+  kubeadm_version=$kubeadm_version yq -i '.asciidoc.attributes.kubeadm_version=strenv(kubeadm_version)' $antora_file_path
+
+  rke2_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "rke2" and .type == "ControlPlaneProvider").url' | cut -d'/' -f7`
+  echo "Found CAPRKE2 version: $rke2_version"
+  rke2_version=$rke2_version yq -i '.asciidoc.attributes.rke2_version=strenv(rke2_version)' $antora_file_path
+
+  fleet_addon_version=`echo "$clusterctl_config" | yq '.providers[] | select(.name == "rancher-fleet" and .type == "AddonProvider").url' | cut -d'/' -f7`
+  echo "Found CAAPF version: $fleet_addon_version"
+  fleet_addon_version=$fleet_addon_version yq -i '.asciidoc.attributes.fleet_addon_version=strenv(fleet_addon_version)' $antora_file_path
+done

--- a/.github/workflows/sync-certified-providers-version.yaml
+++ b/.github/workflows/sync-certified-providers-version.yaml
@@ -1,0 +1,43 @@
+name: "Sync Certified Providers Version"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run sync script
+        run: |
+          BRANCH="sync-certified-providers-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+          git checkout -b "$BRANCH"
+          .github/scripts/sync-certified-providers-version.sh
+          git add versions/*
+          if git diff --cached --quiet; then
+            echo "No changes detected"
+            echo "SKIP_PUSH=true" >> $GITHUB_ENV
+          else
+            git commit -m "chore: update certified providers version"
+            echo "SKIP_PUSH=false" >> $GITHUB_ENV
+          fi
+      - name: Push and create pull request
+        if: env.SKIP_PUSH == 'false'
+        run: |
+          git push origin "$BRANCH"
+          body="This PR syncs the Certified Providers Version."
+
+          gh pr create \
+            --title "chore: update certified providers version" \
+            --body "$body" \
+            --head "${{ github.repository_owner }}:$BRANCH" \
+            --base "main" \
+

--- a/versions/v0.25/antora-yml/antora-product.yml
+++ b/versions/v0.25/antora-yml/antora-product.yml
@@ -10,5 +10,13 @@ asciidoc:
     #Prerequisite and Component version attributes
     rancher_version: v2.13.3
     turtles_version: v0.25.4
+    aws_version: v2.9.1
+    azure_version: v1.21.0
+    gcp_version: v1.10.0
+    vsphere_version: v1.13.1
+    docker_version: v1.10.6
+    kubeadm_version: v1.10.6
+    rke2_version: v0.21.1
+    fleet_addon_version: v0.12.0
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.25/modules/en/pages/overview/certified.adoc
+++ b/versions/v0.25/modules/en/pages/overview/certified.adoc
@@ -17,47 +17,95 @@ This list is constantly evolving to reflect the ongoing development of the proje
 This is a list of the officially certified CAPI Providers by Turtles. These providers are covered by our test suite and we actively ensure that they work properly with the CAPI extension for Rancher.
 
 |===
-| Platform | Code Name | Provider Type | Docs
+| Platform | Code Name | Provider Type | Docs | Version
 
 | *RKE2*
 | CAPRKE2
 | Bootstrap/Control Plane
 | https://rancher.github.io/cluster-api-provider-rke2[CAPRKE2 book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/rancher/cluster-api-provider-rke2/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{rke2_version}
+endif::[]
 
 | *Kubeadm*
 | Kubeadm
 | Bootstrap/Control Plane
 | https://cluster-api.sigs.k8s.io/tasks/bootstrap/kubeadm-bootstrap[CABPK docs]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{kubeadm_version}
+endif::[]
 
 | *AWS*
 | CAPA
 | Infrastructure
 | https://cluster-api-aws.sigs.k8s.io[CAPA book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{aws_version}
+endif::[]
 
 | *Docker**
 | CAPD
 | Infrastructure
 | https://cluster-api.sigs.k8s.io[CAPI book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{docker_version}
+endif::[]
 
 | *vSphere*
 | CAPV
 | Infrastructure
 | https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/docs/getting_started.md[CAPV docs]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{vsphere_version}
+endif::[]
 
 | *Azure*
 | CAPZ
 | Infrastructure
 | https://capz.sigs.k8s.io/[CAPZ book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{azure_version}
+endif::[]
 
 | *GCP* (Only GKE managed clusters)
 | CAPG
 | Infrastructure
 | https://cluster-api-gcp.sigs.k8s.io/[CAPG book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{gcp_version}
+endif::[]
 
 | *Addon Provider Fleet*
 | CAAPF
 | Addon
 | https://rancher.github.io/cluster-api-addon-provider-fleet/[CAAPF book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/rancher/cluster-api-addon-provider-fleet/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{fleet_addon_version}
+endif::[]
 |===
 
 *Recommended only for development purposes.

--- a/versions/v0.25/modules/en/pages/reference/capiprovider.adoc
+++ b/versions/v0.25/modules/en/pages/reference/capiprovider.adoc
@@ -8,7 +8,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 Every field provided by the upstream CAPI Operator `CAPIProviderSpec` resource is also available in the spec of the `CAPIProvider` resource. Feel free to refer to upstream configuration link:https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/05_provider-spec-configuration[guides] for advanced scenarios.
 
-All the xref:../overview/certified.adoc[certified] CAPI Providers are configured using an embedded configuration. In order to override it, a custom xref:./clusterctlconfig.adoc#_override_a_certified_provider_version[ClusterctlConfig] needs to be created.
+All the xref:../overview/certified.adoc[certified] CAPI Providers are configured using an embedded configuration. In order to override it, a custom xref:./clusterctlconfig.adoc#_override_a_capiprovider_version[ClusterctlConfig] needs to be created.
 
 == Usage
 
@@ -63,7 +63,18 @@ The key fields in the `CAPIProvider` spec are:
 
 == Version pinning and automatic updates
 
-The `CAPIProvider` `version` can be set at any time to pin the provider to a specific version. Additionally, `automaticUpdates` can be toggled to allow automatic updates to the latest version available. The latest version available is determined by the embedded clusterctl configuration for xref:../overview/certified.adoc[certified] providers, and it can be overridden or configured for custom providers using xref:../reference/clusterctlconfig.adoc[ClusterctlConfig].
+The `CAPIProvider.spec.version` can be set to pin the provider to a specific version. Additionally, `CAPIProvider.spec.enableAutomaticUpdates` can be toggled to allow automatic updates to the latest version available.
+
+ifeval::["{build-type}" == "community"]
+When using `EnableAutomaticUpdates`, the *latest* version available depends on the upstream provider release.  +
+For a list of known providers, please refer to the https://cluster-api.sigs.k8s.io/clusterctl/commands/init#which-providers-can-i-use[clusterctl documentation].
+endif::[]
+ifeval::["{build-type}" == "product"]
+For certified providers, when using `EnableAutomaticUpdates`, the *latest* version available is determined by the {product_name} embedded clusterctl configuration. Pinned versions are documented in the xref:../overview/certified.adoc#_list_of_certified_providers[certified providers table].  +
+For all other providers, please refer to the https://cluster-api.sigs.k8s.io/clusterctl/commands/init#which-providers-can-i-use[clusterctl documentation].
+endif::[]
+
+Users can also limit the *latest* available version of any provider using the xref:../reference/clusterctlconfig.adoc#_override_a_capiprovider_version[ClusterctlConfig].
 
 == Deletion
 

--- a/versions/v0.25/modules/en/pages/reference/clusterctlconfig.adoc
+++ b/versions/v0.25/modules/en/pages/reference/clusterctlconfig.adoc
@@ -51,8 +51,10 @@ https://github.com/metal3-io/cluster-api-provider-metal3/releases/v1.10.1/infras
 * `images[].repository` - Sets the container registry override to pull images from
 * `images[].tag` - Allows to specify a tag for the images
 
-== Override a Certified Provider version
+[#_override_a_capiprovider_version]
+== Override a CAPIProvider version
 
+ifeval::["{build-type}" == "product"]
 {product_name} embeds a validated configuration where all certified provider versions are pinned.  +
 Typically versions are updated with any relese of {product_name}.  
 
@@ -60,6 +62,7 @@ Typically versions are updated with any relese of {product_name}.
 ====
 - {product_name} only validates the embedded configuration for certified providers. Any customization to the embedded configuration can eventually lead to incompatibilities and unsupported scenarios. 
 ====
+endif::[]
 
 In order to override a provider version, or to use a different registry to pull images, a `ClusterctlConfig` can be defined.  +
 For more information on image override, please refer to the upstream link:https://cluster-api.sigs.k8s.io/clusterctl/configuration#image-overrides[documentation].  

--- a/versions/v0.26/antora-yml/antora-product.yml
+++ b/versions/v0.26/antora-yml/antora-product.yml
@@ -10,6 +10,14 @@ asciidoc:
     #Prerequisite and Component version attributes
     rancher_version: v2.14.0
     turtles_version: v0.26.0
+    aws_version: "v2.10.1"
+    azure_version: v1.22.0
+    gcp_version: v1.11.1
+    vsphere_version: v1.15.2
+    docker_version: v1.12.2
+    kubeadm_version: v1.12.2
+    rke2_version: v0.24.2
+    fleet_addon_version: v0.14.1
 nav:
   - modules/en/nav.adoc
   - modules/de/nav.adoc

--- a/versions/v0.26/modules/en/pages/overview/certified.adoc
+++ b/versions/v0.26/modules/en/pages/overview/certified.adoc
@@ -18,47 +18,95 @@ This list is constantly evolving to reflect the ongoing development of the proje
 This is a list of the officially certified CAPI Providers by Turtles. These providers are covered by our test suite and we actively ensure that they work properly with the CAPI extension for Rancher.
 
 |===
-| Platform | Code Name | Provider Type | Docs
+| Platform | Code Name | Provider Type | Docs | Version
 
 | *RKE2*
 | CAPRKE2
 | Bootstrap/Control Plane
 | https://rancher.github.io/cluster-api-provider-rke2[CAPRKE2 book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/rancher/cluster-api-provider-rke2/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{rke2_version}
+endif::[]
 
 | *Kubeadm*
 | Kubeadm
 | Bootstrap/Control Plane
 | https://cluster-api.sigs.k8s.io/tasks/bootstrap/kubeadm-bootstrap[CABPK docs]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{kubeadm_version}
+endif::[]
 
 | *AWS*
 | CAPA
 | Infrastructure
 | https://cluster-api-aws.sigs.k8s.io[CAPA book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{aws_version}
+endif::[]
 
 | *Docker**
 | CAPD
 | Infrastructure
 | https://cluster-api.sigs.k8s.io[CAPI book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{docker_version}
+endif::[]
 
 | *vSphere*
 | CAPV
 | Infrastructure
 | https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/docs/getting_started.md[CAPV docs]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{vsphere_version}
+endif::[]
 
 | *Azure*
 | CAPZ
 | Infrastructure
 | https://capz.sigs.k8s.io/[CAPZ book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{azure_version}
+endif::[]
 
 | *GCP* (Only GKE managed clusters)
 | CAPG
 | Infrastructure
 | https://cluster-api-gcp.sigs.k8s.io/[CAPG book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{gcp_version}
+endif::[]
 
 | *Addon Provider Fleet*
 | CAAPF
 | Addon
 | https://rancher.github.io/cluster-api-addon-provider-fleet/[CAAPF book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/rancher/cluster-api-addon-provider-fleet/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{fleet_addon_version}
+endif::[]
 |===
 
 *Recommended only for development purposes.

--- a/versions/v0.26/modules/en/pages/reference/capiprovider.adoc
+++ b/versions/v0.26/modules/en/pages/reference/capiprovider.adoc
@@ -9,7 +9,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 Every field provided by the upstream CAPI Operator `CAPIProviderSpec` resource is also available in the spec of the `CAPIProvider` resource. Feel free to refer to upstream configuration link:https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/05_provider-spec-configuration[guides] for advanced scenarios.
 
-All the xref:../overview/certified.adoc[certified] CAPI Providers are configured using an embedded configuration. In order to override it, a custom xref:./clusterctlconfig.adoc#_override_a_certified_provider_version[ClusterctlConfig] needs to be created.
+All the xref:../overview/certified.adoc[certified] CAPI Providers are configured using an embedded configuration. In order to override it, a custom xref:./clusterctlconfig.adoc#_override_a_capiprovider_version[ClusterctlConfig] needs to be created.
 
 == Usage
 
@@ -64,7 +64,18 @@ The key fields in the `CAPIProvider` spec are:
 
 == Version pinning and automatic updates
 
-The `CAPIProvider` `version` can be set at any time to pin the provider to a specific version. Additionally, `automaticUpdates` can be toggled to allow automatic updates to the latest version available. The latest version available is determined by the embedded clusterctl configuration for xref:../overview/certified.adoc[certified] providers, and it can be overridden or configured for custom providers using xref:../reference/clusterctlconfig.adoc[ClusterctlConfig].
+The `CAPIProvider.spec.version` can be set to pin the provider to a specific version. Additionally, `CAPIProvider.spec.enableAutomaticUpdates` can be toggled to allow automatic updates to the latest version available.
+
+ifeval::["{build-type}" == "community"]
+When using `EnableAutomaticUpdates`, the *latest* version available depends on the upstream provider release.  +
+For a list of known providers, please refer to the https://cluster-api.sigs.k8s.io/clusterctl/commands/init#which-providers-can-i-use[clusterctl documentation].
+endif::[]
+ifeval::["{build-type}" == "product"]
+For certified providers, when using `EnableAutomaticUpdates`, the *latest* version available is determined by the {product_name} embedded clusterctl configuration. Pinned versions are documented in the xref:../overview/certified.adoc#_list_of_certified_providers[certified providers table].  +
+For all other providers, please refer to the https://cluster-api.sigs.k8s.io/clusterctl/commands/init#which-providers-can-i-use[clusterctl documentation].
+endif::[]
+
+Users can also limit the *latest* available version of any provider using the xref:../reference/clusterctlconfig.adoc#_override_a_capiprovider_version[ClusterctlConfig].
 
 == Deletion
 

--- a/versions/v0.26/modules/en/pages/reference/clusterctlconfig.adoc
+++ b/versions/v0.26/modules/en/pages/reference/clusterctlconfig.adoc
@@ -52,9 +52,10 @@ https://github.com/metal3-io/cluster-api-provider-metal3/releases/v1.10.1/infras
 * `images[].repository` - Sets the container registry override to pull images from
 * `images[].tag` - Allows to specify a tag for the images
 
-[#_override_a_certified_provider_version]
-== Override a Certified Provider version
+[#_override_a_capiprovider_version]
+== Override a CAPIProvider version
 
+ifeval::["{build-type}" == "product"]
 {product_name} embeds a validated configuration where all certified provider versions are pinned.  +
 Typically versions are updated with any relese of {product_name}.  
 
@@ -62,6 +63,8 @@ Typically versions are updated with any relese of {product_name}.
 ====
 - {product_name} only validates the embedded configuration for certified providers. Any customization to the embedded configuration can eventually lead to incompatibilities and unsupported scenarios. 
 ====
+endif::[]
+
 
 In order to override a provider version, or to use a different registry to pull images, a `ClusterctlConfig` can be defined.  +
 For more information on image override, please refer to the upstream link:https://cluster-api.sigs.k8s.io/clusterctl/configuration#image-overrides[documentation].  

--- a/versions/v0.27/antora-yml/antora-product.yml
+++ b/versions/v0.27/antora-yml/antora-product.yml
@@ -10,5 +10,13 @@ asciidoc:
     #Prerequisite and Component version attributes
     rancher_version: v2.14.0
     turtles_version: v0.27.0
+    aws_version: "v2.10.1"
+    azure_version: v1.22.0
+    gcp_version: v1.11.1
+    vsphere_version: v1.15.2
+    docker_version: v1.12.2
+    kubeadm_version: v1.12.2
+    rke2_version: v0.24.2
+    fleet_addon_version: v0.14.1
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.27/modules/en/pages/overview/certified.adoc
+++ b/versions/v0.27/modules/en/pages/overview/certified.adoc
@@ -17,47 +17,95 @@ This list is constantly evolving to reflect the ongoing development of the proje
 This is a list of the officially certified CAPI Providers by Turtles. These providers are covered by our test suite and we actively ensure that they work properly with the CAPI extension for Rancher.
 
 |===
-| Platform | Code Name | Provider Type | Docs
+| Platform | Code Name | Provider Type | Docs | Version
 
 | *RKE2*
 | CAPRKE2
 | Bootstrap/Control Plane
 | https://rancher.github.io/cluster-api-provider-rke2[CAPRKE2 book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/rancher/cluster-api-provider-rke2/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{rke2_version}
+endif::[]
 
 | *Kubeadm*
 | Kubeadm
 | Bootstrap/Control Plane
 | https://cluster-api.sigs.k8s.io/tasks/bootstrap/kubeadm-bootstrap[CABPK docs]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{kubeadm_version}
+endif::[]
 
 | *AWS*
 | CAPA
 | Infrastructure
 | https://cluster-api-aws.sigs.k8s.io[CAPA book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{aws_version}
+endif::[]
 
 | *Docker**
 | CAPD
 | Infrastructure
 | https://cluster-api.sigs.k8s.io[CAPI book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{docker_version}
+endif::[]
 
 | *vSphere*
 | CAPV
 | Infrastructure
 | https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/docs/getting_started.md[CAPV docs]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{vsphere_version}
+endif::[]
 
 | *Azure*
 | CAPZ
 | Infrastructure
 | https://capz.sigs.k8s.io/[CAPZ book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{azure_version}
+endif::[]
 
 | *GCP* (Only GKE managed clusters)
 | CAPG
 | Infrastructure
 | https://cluster-api-gcp.sigs.k8s.io/[CAPG book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{gcp_version}
+endif::[]
 
 | *Addon Provider Fleet*
 | CAAPF
 | Addon
 | https://rancher.github.io/cluster-api-addon-provider-fleet/[CAAPF book]
+ifeval::["{build-type}" == "community"]
+|https://github.com/rancher/cluster-api-addon-provider-fleet/releases/latest[latest]
+endif::[]
+ifeval::["{build-type}" == "product"]
+|{fleet_addon_version}
+endif::[]
 |===
 
 *Recommended only for development purposes.

--- a/versions/v0.27/modules/en/pages/reference/capiprovider.adoc
+++ b/versions/v0.27/modules/en/pages/reference/capiprovider.adoc
@@ -8,7 +8,7 @@ The `CAPIProvider` resource allows managing Cluster API Operator manifests in a 
 
 Every field provided by the upstream CAPI Operator `CAPIProviderSpec` resource is also available in the spec of the `CAPIProvider` resource. Feel free to refer to upstream configuration link:https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/05_provider-spec-configuration[guides] for advanced scenarios.
 
-All the xref:../overview/certified.adoc[certified] CAPI Providers are configured using an embedded configuration. In order to override it, a custom xref:./clusterctlconfig.adoc#_override_a_certified_provider_version[ClusterctlConfig] needs to be created.
+All the xref:../overview/certified.adoc[certified] CAPI Providers are configured using an embedded configuration. In order to override it, a custom xref:./clusterctlconfig.adoc#_override_a_capiprovider_version[ClusterctlConfig] needs to be created.
 
 == Usage
 
@@ -63,7 +63,18 @@ The key fields in the `CAPIProvider` spec are:
 
 == Version pinning and automatic updates
 
-The `CAPIProvider` `version` can be set at any time to pin the provider to a specific version. Additionally, `automaticUpdates` can be toggled to allow automatic updates to the latest version available. The latest version available is determined by the embedded clusterctl configuration for xref:../overview/certified.adoc[certified] providers, and it can be overridden or configured for custom providers using xref:../reference/clusterctlconfig.adoc[ClusterctlConfig].
+The `CAPIProvider.spec.version` can be set to pin the provider to a specific version. Additionally, `CAPIProvider.spec.enableAutomaticUpdates` can be toggled to allow automatic updates to the latest version available.
+
+ifeval::["{build-type}" == "community"]
+When using `EnableAutomaticUpdates`, the *latest* version available depends on the upstream provider release.  +
+For a list of known providers, please refer to the https://cluster-api.sigs.k8s.io/clusterctl/commands/init#which-providers-can-i-use[clusterctl documentation].
+endif::[]
+ifeval::["{build-type}" == "product"]
+For certified providers, when using `EnableAutomaticUpdates`, the *latest* version available is determined by the {product_name} embedded clusterctl configuration. Pinned versions are documented in the xref:../overview/certified.adoc#_list_of_certified_providers[certified providers table].  +
+For all other providers, please refer to the https://cluster-api.sigs.k8s.io/clusterctl/commands/init#which-providers-can-i-use[clusterctl documentation].
+endif::[]
+
+Users can also limit the *latest* available version of any provider using the xref:../reference/clusterctlconfig.adoc#_override_a_capiprovider_version[ClusterctlConfig].
 
 == Deletion
 

--- a/versions/v0.27/modules/en/pages/reference/clusterctlconfig.adoc
+++ b/versions/v0.27/modules/en/pages/reference/clusterctlconfig.adoc
@@ -51,9 +51,10 @@ https://github.com/metal3-io/cluster-api-provider-metal3/releases/v1.10.1/infras
 * `images[].repository` - Sets the container registry override to pull images from
 * `images[].tag` - Allows to specify a tag for the images
 
-[#_override_a_certified_provider_version]
-== Override a Certified Provider version
+[#_override_a_capiprovider_version]
+== Override a CAPIProvider version
 
+ifeval::["{build-type}" == "product"]
 {product_name} embeds a validated configuration where all certified provider versions are pinned.  +
 Typically versions are updated with any relese of {product_name}.  
 
@@ -61,6 +62,7 @@ Typically versions are updated with any relese of {product_name}.
 ====
 - {product_name} only validates the embedded configuration for certified providers. Any customization to the embedded configuration can eventually lead to incompatibilities and unsupported scenarios. 
 ====
+endif::[]
 
 In order to override a provider version, or to use a different registry to pull images, a `ClusterctlConfig` can be defined.  +
 For more information on image override, please refer to the upstream link:https://cluster-api.sigs.k8s.io/clusterctl/configuration#image-overrides[documentation].  


### PR DESCRIPTION
Fixes https://github.com/rancher/turtles-product-docs/issues/173
Fixes https://github.com/rancher/turtles-product-docs/issues/174

@salasberryfin @yiannistri may you please let me know if this is addressing #173 fully or if we need something more?

This is also a reminded that documentation for version pinning exists already. Please read:
- https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html#_version_pinning_and_automatic_updates
- https://turtles.docs.rancher.com/turtles/stable/en/reference/clusterctlconfig.html#_override_a_certified_provider_version

If the current documentation is unclear or missing anything, may you elaborate on what can be improved? Thank you.