### PR TITLE
v0.26 - Update Providers Link/README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,27 +79,12 @@ The Makefile can be used to set up your environment, build the local and remote 
 
 You can use the `make` command to build the documentation site locally or remotely for either the Community or Product versions. The Makefile defines various tasks for building the site using different playbooks.
 
-=== Example: Build the site using the development playbook - Product
-
-For development purposes, you can build the product site using the development playbook by running:
+Below is an example using the `make` command to build the local version of the product documentation site:
 
 [,console]
 ----
-make dev-product
+make local-product
 ----
-
-This will use the `turtles-dev-product-playbook.yml` to generate the site with development settings.
-
-=== Preview the development build locally - Product
-
-To preview the above example development site locally, use the command below:
-
-[,console]
-----
-make preview-dev-product
-----
-
-and then open `http://127.0.0.1:8084/` in your browser for a web server preview.
 
 === Clean up the build:
 

--- a/README.adoc
+++ b/README.adoc
@@ -86,6 +86,19 @@ Below is an example using the `make` command to build the local version of the p
 make local-product
 ----
 
+This will use the `turtles-local-product-playbook.yml` to generate the site with product settings.
+
+=== Preview the build locally - Product
+
+To preview the above product example site locally, use the command below:
+
+[,console]
+----
+make preview-local-product
+----
+
+and then open `http://127.0.0.1:8080/` in your browser for a web server preview.
+
 === Clean up the build:
 
 To remove the build and temporary directories, use the following command:

--- a/versions/v0.26/modules/en/pages/tutorials/rancher.adoc
+++ b/versions/v0.26/modules/en/pages/tutorials/rancher.adoc
@@ -57,11 +57,10 @@ The core CAPI controller manifest is embedded in a ConfigMap, which simplifies o
 
 == Installing CAPI Providers
 
-With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource, and a separate
-providers chart is available for installing certified providers. 
+With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
 ifeval::["{build-type}" == "product"]
-For more information on provider charts available for Prime users, refer to xref:user/providers.adoc[Install certified providers].
+A separate providers chart is available for installing certified providers. For more information on provider charts available for Prime users, refer to xref:user/providers.adoc[Install certified providers].
 endif::[]
 
 For example, to define a provider:

--- a/versions/v0.26/modules/en/pages/tutorials/rancher.adoc
+++ b/versions/v0.26/modules/en/pages/tutorials/rancher.adoc
@@ -60,7 +60,7 @@ The core CAPI controller manifest is embedded in a ConfigMap, which simplifies o
 With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
 ifeval::["{build-type}" == "product"]
-A separate providers chart is available for installing certified providers. For more information on provider charts available for Prime users, refer to xref:user/providers.adoc[Install certified providers].
+A separate providers chart for Prime users is available for installing certified providers. For more information, refer to xref:user/providers.adoc[Install certified providers].
 endif::[]
 
 For example, to define a provider:

--- a/versions/v0.26/modules/en/pages/tutorials/rancher.adoc
+++ b/versions/v0.26/modules/en/pages/tutorials/rancher.adoc
@@ -1,6 +1,6 @@
 = Rancher Setup
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-02-18
+:revdate: 2026-04-16
 :page-revdate: {revdate}
 
 == Installing Rancher
@@ -58,7 +58,11 @@ The core CAPI controller manifest is embedded in a ConfigMap, which simplifies o
 == Installing CAPI Providers
 
 With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource, and a separate
-providers chart is available for installing certified providers. For more information on the providers chart, refer to xref:user/providers.adoc[Install certified providers].
+providers chart is available for installing certified providers. 
+
+ifeval::["{build-type}" == "product"]
+For more information on provider charts available for Prime users, refer to xref:user/providers.adoc[Install certified providers].
+endif::[]
 
 For example, to define a provider:
 

--- a/versions/v0.27/modules/en/pages/tutorials/rancher.adoc
+++ b/versions/v0.27/modules/en/pages/tutorials/rancher.adoc
@@ -59,7 +59,7 @@ The core CAPI controller manifest is embedded in a ConfigMap, which simplifies o
 With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
 ifeval::["{build-type}" == "product"]
-A separate providers chart is available for installing certified providers. For more information on provider charts available for Prime users, refer to xref:user/providers.adoc[Install certified providers].
+A separate providers chart for Prime users is available for installing certified providers. For more information, refer to xref:user/providers.adoc[Install certified providers].
 endif::[]
 
 For example, to define a provider:

--- a/versions/v0.27/modules/en/pages/tutorials/rancher.adoc
+++ b/versions/v0.27/modules/en/pages/tutorials/rancher.adoc
@@ -1,5 +1,5 @@
 = Rancher Setup
-:revdate: 2026-02-18
+:revdate: 2026-04-16
 :page-revdate: {revdate}
 
 == Installing Rancher
@@ -56,8 +56,11 @@ The core CAPI controller manifest is embedded in a ConfigMap, which simplifies o
 
 == Installing CAPI Providers
 
-With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource, and a separate
-providers chart is available for installing certified providers. For more information on the providers chart, refer to xref:user/providers.adoc[Install certified providers].
+With {product_name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
+
+ifeval::["{build-type}" == "product"]
+A separate providers chart is available for installing certified providers. For more information on provider charts available for Prime users, refer to xref:user/providers.adoc[Install certified providers].
+endif::[]
 
 For example, to define a provider:
 


### PR DESCRIPTION
Adding conditionals to providers.adoc page link in Rancher tutorial page as intended for Prime customers only, removing from Community build. Updating README with removing dev build example as dev is rendered alongside product/comm builds now.

@furkatgofurov7 do you mind reviewing when you have a moment as you were the [last to update](https://github.com/rancher/turtles-product-docs/pull/138) the Rancher page, let me know if there are any questions, thanks!

Related to https://github.com/rancher/turtles-product-docs/issues/182