### PR TITLE
fix: remove misleading features config note

### DIFF
--- a/versions/v0.26/modules/en/pages/overview/features.adoc
+++ b/versions/v0.26/modules/en/pages/overview/features.adoc
@@ -105,8 +105,3 @@ kubectl patch configmap rancher-config -n cattle-system --type=merge -p '
 ----
 
 Rancher then reads this ConfigMap and passes these values to the {product_name} controller.
-
-[CAUTION]
-====
-Note that because `rancher-turtles` is a plain string value (containing embedded YAML), the patch replaces the entire string — so include all desired feature gate entries in the patch as well as any other settings, not just the ones you are changing, to avoid inadvertently dropping settings that were previously present under that key.
-====


### PR DESCRIPTION
@yiannistri (@cpinjani @valaparthvi FYI as well) 

I couldn't reproduce this.
I installed Turtles, then edited the cattle-system/rancher-config configmap as follows:

```yaml
data:
  rancher-turtles: |
    use-caapf:
      enabled: true
```

And it works as expected, no other feature is overridden. Rancher should just override the Turtles chart values, so defaults will stay if not configured.

For a feedback I implemented https://github.com/rancher/turtles/pull/2343

This is what I get initially:

```
I0501 06:37:31.114814       1 main.go:137] "Feature 'agent-tls-mode' enabled: true" logger="setup"
I0501 06:37:31.114914       1 main.go:137] "Feature 'ui-plugin' enabled: false" logger="setup"
I0501 06:37:31.114923       1 main.go:137] "Feature 'no-cert-manager' enabled: true" logger="setup"
I0501 06:37:31.114931       1 main.go:137] "Feature 'use-rancher-default-registry' enabled: true" logger="setup"
I0501 06:37:31.114940       1 main.go:137] "Feature 'use-caapf' enabled: false" logger="setup"
```

This after the ConfigMap is patched:

```
I0501 06:42:27.824084       1 main.go:137] "Feature 'ui-plugin' enabled: false" logger="setup"
I0501 06:42:27.824138       1 main.go:137] "Feature 'no-cert-manager' enabled: true" logger="setup"
I0501 06:42:27.824145       1 main.go:137] "Feature 'use-rancher-default-registry' enabled: true" logger="setup"
I0501 06:42:27.824151       1 main.go:137] "Feature 'use-caapf' enabled: true" logger="setup"
I0501 06:42:27.824157       1 main.go:137] "Feature 'agent-tls-mode' enabled: true" logger="setup"
```
I feel like the Caution note is incorrect and unnecessary. Am I missing anything?