### PR TITLE
Product Conditional - certification.adoc

### DIFF
--- a/versions/v0.17/modules/en/nav.adoc
+++ b/versions/v0.17/modules/en/nav.adoc
@@ -17,7 +17,9 @@
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/capiprovider.adoc[Install CAPI Providers]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.17/modules/en/pages/index.adoc
+++ b/versions/v0.17/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-02-27
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 :page_project_origin: /intro.md
 :page_project_slug: /
@@ -34,7 +34,12 @@ Learn how to use {product_name} to xref:./user/clusters.adoc[manage your CAPI cl
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers] or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.17/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.17/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-15
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../reference/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.18/modules/en/nav.adoc
+++ b/versions/v0.18/modules/en/nav.adoc
@@ -19,7 +19,9 @@
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/capiprovider.adoc[Install CAPI Providers]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.18/modules/en/pages/index.adoc
+++ b/versions/v0.18/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-04-04
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is Rancher Turtles?
@@ -32,7 +32,12 @@ Learn how to use {product_name} to xref:./user/clusters.adoc[manage your CAPI cl
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers] or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.18/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.18/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-15
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../reference/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.19/modules/en/nav.adoc
+++ b/versions/v0.19/modules/en/nav.adoc
@@ -19,7 +19,9 @@
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/capiprovider.adoc[Install CAPI Providers]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.19/modules/en/pages/index.adoc
+++ b/versions/v0.19/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-05-06
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is Rancher Turtles?
@@ -32,7 +32,12 @@ Learn how to use {product_name} to xref:./user/clusters.adoc[manage your CAPI cl
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers] or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.19/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.19/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-15
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../reference/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.20/modules/en/nav.adoc
+++ b/versions/v0.20/modules/en/nav.adoc
@@ -19,7 +19,9 @@
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/capiprovider.adoc[Install CAPI Providers]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.20/modules/en/pages/index.adoc
+++ b/versions/v0.20/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-05-30
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is Rancher Turtles?
@@ -41,8 +41,12 @@ Learn how to use {product_name} to xref:./user/clusters.adoc[manage your CAPI cl
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers] or xref:./operator/certification.adoc[certifying the provider of your choice].
-
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or how to xref:./operator/capiprovider.adoc[install and manage CAPI Providers].
+endif::[]
 === Developer Guide
 
 If you are interested in contributing to {product_name}, this section will guide you through the process of setting up your xref:./developer/development.adoc[development environment] and understanding the xref:./developer/guidelines.adoc[guidelines] for contributing.

--- a/versions/v0.20/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.20/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-15
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../reference/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.21/modules/en/nav.adoc
+++ b/versions/v0.21/modules/en/nav.adoc
@@ -21,7 +21,9 @@
 ** xref:operator/chart.adoc[Chart Configuration]
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.21/modules/en/pages/index.adoc
+++ b/versions/v0.21/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-07-01
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is Rancher Turtles?
@@ -45,7 +45,12 @@ Learn how to use {product_name} to xref:./user/clusters.adoc[manage your CAPI cl
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.21/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.21/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-15
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.22/modules/en/nav.adoc
+++ b/versions/v0.22/modules/en/nav.adoc
@@ -20,7 +20,9 @@
 ** xref:operator/chart.adoc[Chart Configuration]
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.22/modules/en/pages/index.adoc
+++ b/versions/v0.22/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-08-01
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is Rancher Turtles?
@@ -45,7 +45,12 @@ Learn how to use {product_name} to xref:./user/clusterclass.adoc[manage your CAP
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.22/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.22/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-15
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.23/modules/en/nav.adoc
+++ b/versions/v0.23/modules/en/nav.adoc
@@ -21,7 +21,9 @@
 ** xref:operator/chart.adoc[Chart Configuration]
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.23/modules/en/pages/index.adoc
+++ b/versions/v0.23/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-08-01
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is Rancher Turtles?
@@ -45,7 +45,12 @@ Learn how to use {product_name} to xref:./user/clusterclass.adoc[manage your CAP
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.23/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.23/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.24/modules/en/nav.adoc
+++ b/versions/v0.24/modules/en/nav.adoc
@@ -22,7 +22,9 @@
 ** xref:operator/chart.adoc[Chart Configuration]
 ** xref:operator/manual.adoc[Manual Installation]
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.24/modules/en/pages/index.adoc
+++ b/versions/v0.24/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-08-01
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 == What is {product_name}?
@@ -45,7 +45,12 @@ Learn how to use {product_name} to xref:./user/clusterclass.adoc[manage your CAP
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments], or xref:./operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, like xref:./operator/manual.adoc[customizing your {product_name} installation], e.g. configuring {product_name} for more advanced scenarios like xref:./operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.24/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.24/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.25/modules/en/nav.adoc
+++ b/versions/v0.25/modules/en/nav.adoc
@@ -23,7 +23,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Operator Guide
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.25/modules/en/pages/index.adoc
+++ b/versions/v0.25/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -41,7 +41,12 @@ Learn how to use {product_name} to xref:./user/clusterclass.adoc[manage your CAP
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, such as configuring {product_name} for xref:operator/airgapped.adoc[air-gapped environments], or xref:operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, such as configuring {product_name} for xref:operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.25/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.25/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.26/modules/de/nav.adoc
+++ b/versions/v0.26/modules/de/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Bedienungsanleitung
 ** xref:operator/clusterclass.adoc[Aktivierung von ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Anbieterzertifizierung]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Anbieter-Test-Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped-Umgebung]
 * Entwicklerhandbuch

--- a/versions/v0.26/modules/de/pages/index.adoc
+++ b/versions/v0.26/modules/de/pages/index.adoc
@@ -1,6 +1,6 @@
 = Übersicht
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -42,7 +42,12 @@ Erfahren Sie, wie Sie {product_name} verwenden, um xref:./user/clusterclass.adoc
 
 === Operatorhandbuch
 
+ifeval::["{build-type}" == "product"]
 Sie möchten möglicherweise in fortgeschrittenere Wartungsaufgaben eintauchen, wie z. B. die Konfiguration von {product_name} für xref:operator/airgapped.adoc[Air-Gapped-Umgebungen] oder xref:operator/certification.adoc[die Zertifizierung des Anbieters Ihrer Wahl].
+endif::[]
+ifeval::["{build-type}" == "community"]
+Sie möchten möglicherweise in fortgeschrittenere Wartungsaufgaben eintauchen, wie z. B. die Konfiguration von {product_name} für xref:operator/airgapped.adoc[Air-Gapped-Umgebungen].
+endif::[]
 
 === Entwicklerhandbuch
 

--- a/versions/v0.26/modules/de/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/de/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = Anbieter-Test-Suite
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 Dieser Abschnitt enthält Informationen darüber, wie Sie die vorhandene E2E-Suite nutzen können, um CAPI-Anbieter mit Turtles zu integrieren und zu überprüfen, ob die Bereitstellung und der Import von Clustern wie erwartet funktionieren. Die Validierung führt die folgenden Aktionen aus:
@@ -10,7 +10,9 @@ Dieser Abschnitt enthält Informationen darüber, wie Sie die vorhandene E2E-Sui
 * Installieren Sie Gitea.
 * Führen Sie die Suite aus, die ein Git-Repo erstellt, die Cluster-Vorlage mit Fleet anwendet und überprüft, ob der Cluster erstellt und erfolgreich in Rancher importiert wurde.
 
+ifeval::["{build-type}" == "product"]
 Die Test-Suite kann zur Zertifizierung von Anbietern verwendet werden, die nicht in der xref:../overview/certified.adoc[Zertifizierungstabelle] aufgeführt sind, wie in xref:../operator/certification.adoc[Anbieterzertifizierung] im Detail beschrieben.
+endif::[]
 
 == Wie man es benutzt
 

--- a/versions/v0.26/modules/en/nav.adoc
+++ b/versions/v0.26/modules/en/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Operator Guide
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.26/modules/en/pages/index.adoc
+++ b/versions/v0.26/modules/en/pages/index.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -48,7 +48,12 @@ Learn how to use {product_name} to xref:./user/clusterclass.adoc[manage your CAP
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, such as configuring {product_name} for xref:operator/airgapped.adoc[air-gapped environments], or xref:operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, such as configuring {product_name} for xref:operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.26/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/en/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = Provider Test Suite
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -10,7 +10,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 

--- a/versions/v0.26/modules/es/nav.adoc
+++ b/versions/v0.26/modules/es/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Guía del operador
 ** xref:operator/clusterclass.adoc[Habilitar ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Certificación de proveedores]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Conjunto de pruebas de proveedores]
 ** xref:operator/airgapped.adoc[Entorno aislado]
 * Guía para desarrolladores

--- a/versions/v0.26/modules/es/pages/index.adoc
+++ b/versions/v0.26/modules/es/pages/index.adoc
@@ -1,6 +1,6 @@
 = Descripción general
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -42,7 +42,12 @@ Aprende a usar {product_name} para xref:./user/clusterclass.adoc[gestionar tus c
 
 === Guía del Operador
 
+ifeval::["{build-type}" == "product"]
 Puede que quieras profundizar en tareas de mantenimiento más avanzadas, como configurar {product_name} para xref:operator/airgapped.adoc[entornos aislados], o xref:operator/certification.adoc[certificar el proveedor de tu elección].
+endif::[]
+ifeval::["{build-type}" == "community"]
+Puede que quieras profundizar en tareas de mantenimiento más avanzadas, como configurar {product_name} para xref:operator/airgapped.adoc[entornos aislados].
+endif::[]
 
 === Guía para Desarrolladores
 

--- a/versions/v0.26/modules/es/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/es/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = Suite de Pruebas del Proveedor
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 Esta sección contiene información sobre cómo puedes aprovechar la suite E2E existente para integrar a los proveedores CAPI con Turtles y verificar que el aprovisionamiento y la importación de clústeres funcionan como se espera. La validación realiza las siguientes acciones:
@@ -10,7 +10,9 @@ Esta sección contiene información sobre cómo puedes aprovechar la suite E2E e
 * Instalar Gitea.
 * Ejecutar la suite que creará un repositorio git, aplicará la plantilla del clúster utilizando Fleet y verificará que el clúster se crea e importa correctamente en Rancher.
 
+ifeval::["{build-type}" == "product"]
 La suite de pruebas se puede utilizar para la certificación de proveedores no listados en la xref:../overview/certified.adoc[tabla de Certificación], como se detalla en xref:../operator/certification.adoc[Certificación de Proveedores].
+endif::[]
 
 == Cómo Usarlo
 

--- a/versions/v0.26/modules/fr/nav.adoc
+++ b/versions/v0.26/modules/fr/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Guide de l'opérateur
 ** xref:operator/clusterclass.adoc[Activation de ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Certification des fournisseurs]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Suite de tests des fournisseurs]
 ** xref:operator/airgapped.adoc[Environnement isolé physiquement]
 * Guide du développeur

--- a/versions/v0.26/modules/fr/pages/index.adoc
+++ b/versions/v0.26/modules/fr/pages/index.adoc
@@ -1,6 +1,6 @@
 = Présentation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -42,7 +42,12 @@ Apprenez à utiliser {product_name} pour xref:./user/clusterclass.adoc[gérer vo
 
 === Guide de l'opérateur
 
+ifeval::["{build-type}" == "product"]
 Vous voudrez peut-être vous plonger dans des tâches de maintenance plus avancées, telles que la configuration de {product_name} pour des xref:operator/airgapped.adoc[environnements isolés physiquement], ou xref:operator/certification.adoc[certifier le fournisseur de votre choix].
+endif::[]
+ifeval::["{build-type}" == "community"]
+Vous voudrez peut-être vous plonger dans des tâches de maintenance plus avancées, telles que la configuration de {product_name} pour des xref:operator/airgapped.adoc[environnements isolés physiquement].
+endif::[]
 
 === Guide du développeur
 

--- a/versions/v0.26/modules/fr/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/fr/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = Suite de tests du fournisseur
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 Cette section contient des informations sur la manière dont vous pouvez tirer parti de la suite E2E existante pour intégrer des fournisseurs CAPI avec Turtles et vérifier que le provisionnement et l'importation des clusters fonctionnent comme prévu. La validation effectue les actions suivantes :
@@ -10,7 +10,9 @@ Cette section contient des informations sur la manière dont vous pouvez tirer p
 * Installer Gitea.
 * Exécuter la suite qui créera un dépôt git, appliquera le modèle de cluster en utilisant Fleet et vérifiera que le cluster est créé et importé avec succès dans Rancher.
 
+ifeval::["{build-type}" == "product"]
 La suite de tests peut être utilisée pour la certification des fournisseurs non listés dans le xref:../overview/certified.adoc[tableau de certification], comme détaillé dans xref:../operator/certification.adoc[Certification des fournisseurs].
+endif::[]
 
 == Comment l'utiliser
 

--- a/versions/v0.26/modules/ja/nav.adoc
+++ b/versions/v0.26/modules/ja/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * オペレーターガイド
 ** xref:operator/clusterclass.adoc[ClusterClassを有効にする]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[プロバイダー認証]
+endif::[]
 ** xref:operator/certificationsuite.adoc[プロバイダーのテストスイート]
 ** xref:operator/airgapped.adoc[エアギャップ(された)環境]
 * 開発者ガイド

--- a/versions/v0.26/modules/ja/pages/index.adoc
+++ b/versions/v0.26/modules/ja/pages/index.adoc
@@ -1,6 +1,6 @@
 = 概要
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -42,7 +42,12 @@ image::intro.png[イントロ,640,480]
 
 === オペレーターガイド
 
+ifeval::["{build-type}" == "product"]
 {product_name}をxref:operator/airgapped.adoc[エアギャップ(された)環境]のために構成するなど、より高度なメンテナンスタスクに取り組むことを検討するかもしれません、またはxref:operator/certification.adoc[選択したプロバイダーを認証する]こともあります。
+endif::[]
+ifeval::["{build-type}" == "community"]
+{product_name}をxref:operator/airgapped.adoc[エアギャップ(された)環境]のために構成するなど、より高度なメンテナンスタスクに取り組むことを検討するかもしれません。
+endif::[]
 
 === 開発者ガイド
 

--- a/versions/v0.26/modules/ja/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/ja/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = プロバイダーテストスイート
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 このセクションでは、既存のE2Eスイートを活用して、任意のCAPIプロバイダーをTurtlesに統合し、クラスターのプロビジョニングとインポートが期待通りに機能するかを検証する方法についての情報を提供します。検証は以下のアクションを実行します：
@@ -10,7 +10,9 @@
 * Giteaをインストールします。
 * Gitリポジトリを作成し、Fleetを使用してクラスターのテンプレートを適用し、クラスターが作成され、Rancherに正常にインポートされたことを確認するスイートを実行します。
 
+ifeval::["{build-type}" == "product"]
 テストスイートは、xref:../overview/certified.adoc[認証テーブル]にリストされていないプロバイダーの認証に使用できます。詳細はxref:../operator/certification.adoc[プロバイダー認証]を参照してください。
+endif::[]
 
 == ハウツー
 

--- a/versions/v0.26/modules/pt/nav.adoc
+++ b/versions/v0.26/modules/pt/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Guia do Operador
 ** xref:operator/clusterclass.adoc[Habilitando ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Certificação de Provedor]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Conjunto de Testes de Provedor]
 ** xref:operator/airgapped.adoc[Ambiente Air-Gapped]
 * Guia do Desenvolvedor

--- a/versions/v0.26/modules/pt/pages/index.adoc
+++ b/versions/v0.26/modules/pt/pages/index.adoc
@@ -1,6 +1,6 @@
 = Visão Geral
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -42,7 +42,12 @@ Aprenda a usar {product_name} para xref:./user/clusterclass.adoc[gerenciar seus 
 
 === Guia do Operador
 
+ifeval::["{build-type}" == "product"]
 Você pode querer se aprofundar em tarefas de manutenção mais avançadas, como configurar {product_name} para xref:operator/airgapped.adoc[ambientes air-gapped], ou xref:operator/certification.adoc[certificar o provedor de sua escolha].
+endif::[]
+ifeval::["{build-type}" == "community"]
+Você pode querer se aprofundar em tarefas de manutenção mais avançadas, como configurar {product_name} para xref:operator/airgapped.adoc[ambientes air-gapped].
+endif::[]
 
 === Guia do Desenvolvedor
 

--- a/versions/v0.26/modules/pt/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/pt/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = Conjunto de Testes do Provedor
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 Esta seção contém informações sobre como você pode aproveitar o conjunto E2E existente para integrar qualquer provedor CAPI com Turtles e verificar se o provisionamento e a importação de clusters funcionam como esperado. A validação realiza as seguintes ações:
@@ -10,7 +10,9 @@ Esta seção contém informações sobre como você pode aproveitar o conjunto E
 * Instale o Gitea.
 * Execute o conjunto que criará um repositório git, aplicará o modelo de cluster usando o Fleet e verificará se o cluster foi criado e importado com sucesso no Rancher.
 
+ifeval::["{build-type}" == "product"]
 O conjunto de testes pode ser usado para certificação de provedores não listados na xref:../overview/certified.adoc[Tabela de Certificação], conforme detalhado em xref:../operator/certification.adoc[Certificação de Provedor].
+endif::[]
 
 == Como Usá-lo
 

--- a/versions/v0.26/modules/zh/nav.adoc
+++ b/versions/v0.26/modules/zh/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * 运维人员指南
 ** xref:operator/clusterclass.adoc[启用 ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[提供者认证]
+endif::[]
 ** xref:operator/certificationsuite.adoc[提供者测试套件]
 ** xref:operator/airgapped.adoc[隔离的环境]
 * 开发人员指南

--- a/versions/v0.26/modules/zh/pages/index.adoc
+++ b/versions/v0.26/modules/zh/pages/index.adoc
@@ -1,6 +1,6 @@
 = 概述
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -42,7 +42,12 @@ image::intro.png[intro,640,480]
 
 === Operator 指南
 
+ifeval::["{build-type}" == "product"]
 您可能想深入了解更高级的维护任务，例如为 {product_name} 配置 xref:operator/airgapped.adoc[隔离的环境]，或 xref:operator/certification.adoc[认证您选择的提供者]。
+endif::[]
+ifeval::["{build-type}" == "community"]
+您可能想深入了解更高级的维护任务，例如为 {product_name} 配置 xref:operator/airgapped.adoc[隔离的环境]。
+endif::[]
 
 === 开发人员指南
 

--- a/versions/v0.26/modules/zh/pages/operator/certificationsuite.adoc
+++ b/versions/v0.26/modules/zh/pages/operator/certificationsuite.adoc
@@ -1,6 +1,6 @@
 = 提供者测试套件
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 本节包含有关如何利用现有的端到端套件来集成任何CAPI提供者与Turtles，并验证集群的配置和导入是否按预期工作的信息。验证执行以下操作：
@@ -10,7 +10,9 @@
 * 安装Gitea。
 * 运行将创建git仓库的套件，使用Fleet应用集群模板，并验证集群是否在Rancher中成功创建和导入。
 
+ifeval::["{build-type}" == "product"]
 测试套件可用于未在xref:../overview/certified.adoc[认证表]中列出的提供者的认证，如xref:../operator/certification.adoc[提供者认证]中详细说明。
+endif::[]
 
 == 如何使用它
 

--- a/versions/v0.27/modules/en/nav.adoc
+++ b/versions/v0.27/modules/en/nav.adoc
@@ -22,7 +22,9 @@ ifeval::["{build-type}" == "product"]
 endif::[]
 * Operator Guide
 ** xref:operator/clusterclass.adoc[Enabling ClusterClass]
+ifeval::["{build-type}" == "product"]
 ** xref:operator/certification.adoc[Provider Certification]
+endif::[]
 ** xref:operator/certificationsuite.adoc[Provider Test Suite]
 ** xref:operator/airgapped.adoc[Air-Gapped Environment]
 * Developer Guide

--- a/versions/v0.27/modules/en/pages/index.adoc
+++ b/versions/v0.27/modules/en/pages/index.adoc
@@ -1,5 +1,5 @@
 = Overview
-:revdate: 2025-11-20
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -41,7 +41,12 @@ Learn how to use {product_name} to xref:./user/clusterclass.adoc[manage your CAP
 
 === Operator Guide
 
+ifeval::["{build-type}" == "product"]
 You may want to dive into more advanced maintenance tasks, such as configuring {product_name} for xref:operator/airgapped.adoc[air-gapped environments], or xref:operator/certification.adoc[certifying the provider of your choice].
+endif::[]
+ifeval::["{build-type}" == "community"]
+You may want to dive into more advanced maintenance tasks, such as configuring {product_name} for xref:operator/airgapped.adoc[air-gapped environments].
+endif::[]
 
 === Developer Guide
 

--- a/versions/v0.27/modules/en/pages/operator/certificationsuite.adoc
+++ b/versions/v0.27/modules/en/pages/operator/certificationsuite.adoc
@@ -1,5 +1,5 @@
 = Provider Test Suite
-:revdate: 2025-09-16
+:revdate: 2026-05-13
 :page-revdate: {revdate}
 
 This section contains information on how you can leverage the existing E2E suite to integrate any CAPI providers with Turtles and verify that the provisioning and importing of clusters works as expected. The validation performs the following actions:
@@ -9,7 +9,9 @@ This section contains information on how you can leverage the existing E2E suite
 * Install Gitea.
 * Run the suite that will create a git repo, apply cluster template using Fleet and verify the cluster is created and successfully imported in Rancher.
 
+ifeval::["{build-type}" == "product"]
 The test suite can be used for certification of providers not listed in the xref:../overview/certified.adoc[Certification table], as detailed in xref:../operator/certification.adoc[Provider Certification].
+endif::[]
 
 == How to Use It
 


### PR DESCRIPTION
Adding the product conditional to certification.adoc file in the Operator section, and updating references to the file across versions with conditionals as well.

Overall, three pages were updated per version: certificationsuite.adoc, index.adoc, and nav.adoc

Tied to https://github.com/rancher/turtles-product-docs/issues/198