### PR TITLE
docs: Clarify that use-caapf must be set prior to upgrade

### DIFF
--- a/versions/v0.26/modules/en/pages/user/caapf.adoc
+++ b/versions/v0.26/modules/en/pages/user/caapf.adoc
@@ -80,8 +80,13 @@ spec:
 ----
 ======
 endif::[]
-* Set `features.use-caapf.enabled: true` in the {product_name} chart values to enable the `use-caapf` alpha feature gate (disabled by default).  For instructions on how to set feature gates, refer to xref:overview/features.adoc#_how_to_set_feature_gates[this section].
+* Set `features.use-caapf.enabled: true` in the {product_name} chart values to enable the `use-caapf` alpha feature gate (disabled by default). For instructions on how to set feature gates, refer to xref:overview/features.adoc#_how_to_set_feature_gates[this section].
++
+[IMPORTANT]
+====
+This flag must be set *before* upgrading to Rancher v2.14.1. If the upgrade completes with the flag at its default (`false`), the {product_name} controller will reconcile imported clusters without the `provisioning.cattle.io/externally-managed` annotation, handing Fleet agent management to Rancher. Enabling the flag afterward causes {product_name} to re-add the annotation and hand management back to CAAPF, resulting in the Fleet agent being re-installed on workload clusters.
 
+====
 Once both are in place, Turtles will automatically add the `provisioning.cattle.io/externally-managed` annotation to imported Rancher clusters, delegating Fleet agent installation on CAPI workload clusters to CAAPF rather than Rancher managing it directly.
 
 == Functionality

--- a/versions/v0.26/modules/en/pages/user/caapf.adoc
+++ b/versions/v0.26/modules/en/pages/user/caapf.adoc
@@ -149,5 +149,5 @@ For a tutorial and prerequisites, please refer to https://rancher.github.io/clus
 
 To disable CAAPF and return to Rancher's default Fleet management, you only need to disable the feature gate: Set `features.use-caapf.enabled: false` (the default value) in your {product_name} Helm chart configuration.
 
-Once the feature gate is disabled, Turtles will automatically remove the `provisioning.cattle.io/externally-managed` annotation from any previously managed clusters, and Rancher will resume responsibility for installing and managing the Fleet agent on the workload clusters.
+Once the feature gate is disabled, {product_name} will automatically remove the `provisioning.cattle.io/externally-managed` annotation from any previously managed clusters, and Rancher will resume responsibility for installing and managing the Fleet agent on the workload clusters.
 

--- a/versions/v0.27/modules/en/pages/overview/features.adoc
+++ b/versions/v0.27/modules/en/pages/overview/features.adoc
@@ -9,12 +9,6 @@ This section describes features and feature stages in {product_name}.
 |===
 | Feature | Helm Feature Name | Sub-Feature | Default | Stage 
 
-| *Add-on Provider for Fleet*
-| `addon-provider-fleet`
-| _None_
-| enabled
-| beta
-
 | *Agent TLS Mode*
 | `agent-tls-mode`
 | _None_
@@ -32,6 +26,12 @@ This section describes features and feature stages in {product_name}.
 | _None_
 | enabled
 | beta
+
+| *Use CAAPF*
+| `use-caapf`
+| _None_
+| disabled
+| alpha
 
 |===
 
@@ -80,3 +80,32 @@ Please provide feedback on Alpha and Beta features!
 - Always enabled, cannot be disabled.
 - No feature gate needed.
 - Stable, with long-term support in future releases.
+
+== How to set feature gates
+
+You can set configuration options for all charts that get installed as part of Rancher.
+
+To enable/disable feature gates for the {product_name} chart, patch the `rancher-config` ConfigMap in the `cattle-system` namespace to add or update the `rancher-turtles` key under `.data`. The value of this key is a YAML string containing a features map, where each entry corresponds to a feature gate name from the list above with an enabled boolean field. For example:
+[source,bash]
+----
+kubectl patch configmap rancher-config -n cattle-system --type=merge -p '
+  data:
+    rancher-turtles: |
+      features:
+        agent-tls-mode:
+          enabled: true
+        no-cert-manager:
+          enabled: true
+        use-rancher-default-registry:
+          enabled: true
+        use-caapf:
+          enabled: false
+  '
+----
+
+Rancher then reads this ConfigMap and passes these values to the {product_name} controller.
+
+[CAUTION]
+====
+Note that because `rancher-turtles` is a plain string value (containing embedded YAML), the patch replaces the entire string — so include all desired feature gate entries in the patch as well as any other settings, not just the ones you are changing, to avoid inadvertently dropping settings that were previously present under that key.
+====

--- a/versions/v0.27/modules/en/pages/user/caapf.adoc
+++ b/versions/v0.27/modules/en/pages/user/caapf.adoc
@@ -16,10 +16,77 @@ endif::[]
 For more information about the provider, please refer to https://rancher.github.io/cluster-api-addon-provider-fleet/[CAAPF book].
 ====
 
+[CAUTION]
+====
+Starting with Rancher v2.14.1, CAAPF is no longer installed by default. While standard Fleet integration is still available through Rancher, advanced CAAPF features require manual installation. Review the following scenarios to determine if CAAPF is necessary for your environment:
+
+* **Standard Rancher-Fleet integration**
++
+If you only require your CAPI workload clusters to be registered with Fleet for basic application deployment via Rancher, you **do not need to install CAAPF**. No manual steps are necessary, and when you use the `cluster-api.cattle.io/rancher-auto-import` label, Rancher will automatically register the cluster with Fleet and install the `fleet-agent` as part of the standard import process. Upgrading to Rancher v2.14.1 will result in Rancher updating the `fleet-agent` on any existing downstream clusters.
+
+* **Advanced CAAPF automation**
++
+If you want to use advanced automation provided by CAAPF—such as automatic creation of Fleet `ClusterGroups` based on `ClusterClasses`, automatic label propagation from CAPI to Fleet resources, or CAPI-based Helm templating—you **must install and enable CAAPF manually**. Refer to the <<_prerequisites,prerequisites below>> for more information. In this scenario, CAAPF takes over the responsibility of registering the cluster with Fleet.
+====
+
 [WARNING]
 ====
 CAAPF depends on the `WatchList` Kubernetes feature gate. This feature needs to be explicitly enabled on Kubernetes `1.33` versions. See the https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/[Kubernetes upstream documentation] for further information.
 ====
+
+== Prerequisites
+
+If you have chosen the **Advanced CAAPF automation** scenario and want to continue using CAAPF for its advanced features, two configuration changes are required:
+
+ifeval::["{build-type}" == "product"]
+* Set `providers.addonFleet.enabled: true` in the {product_name} Providers chart values to deploy the CAAPF provider.
+** CAAPF provider installation example:
++
+.Click to Expand
+[%collapsible]
+======
+[,bash]
+----
+helm upgrade --install rancher-turtles-providers oci://<REGISTRY_URL>/rancher/charts/rancher-turtles-providers \
+    --namespace cattle-turtles-system \
+    --set providers.addonFleet.enabled=true \
+    --wait
+----
+======
+endif::[]
+ifeval::["{build-type}" == "community"]
+* Apply a xref:reference/capiprovider.adoc[`CAPIProvider`] manifest for CAAPF in your management cluster.
+** CAAPF provider installation example:
++
+.Click to Expand
+[%collapsible]
+======
+[,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fleet-addon-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: fleet
+  namespace: fleet-addon-system
+spec:
+  name: rancher-fleet
+  type: addon
+----
+======
+endif::[]
+* Set `features.use-caapf.enabled: true` in the {product_name} chart values to enable the `use-caapf` alpha feature gate (disabled by default). For instructions on how to set feature gates, refer to xref:overview/features.adoc#_how_to_set_feature_gates[this section].
++
+[IMPORTANT]
+====
+This flag must be set *before* upgrading to Rancher v2.14.1. If the upgrade completes with the flag at its default (`false`), the {product_name} controller will reconcile imported clusters without the `provisioning.cattle.io/externally-managed` annotation, handing Fleet agent management to Rancher. Enabling the flag afterward causes {product_name} to re-add the annotation and hand management back to CAAPF, resulting in the Fleet agent being re-installed on workload clusters.
+
+====
+Once both are in place, Turtles will automatically add the `provisioning.cattle.io/externally-managed` annotation to imported Rancher clusters, delegating Fleet agent installation on CAPI workload clusters to CAAPF rather than Rancher managing it directly.
 
 == Functionality
 
@@ -76,3 +143,9 @@ For more information on the feature, please refer to https://rancher.github.io/c
 *Demo*: image:https://asciinema.org/a/706570.svg[asciicast,link=https://asciinema.org/a/706570]
 
 For a tutorial and prerequisites, please refer to https://rancher.github.io/cluster-api-addon-provider-fleet/03_tutorials/04_installing_calico_via_gitrepo.html[gitrepo tutorial] section in the book.
+
+== Disabling CAAPF
+
+To disable CAAPF and return to Rancher's default Fleet management, you only need to disable the feature gate: Set `features.use-caapf.enabled: false` (the default value) in your {product_name} Helm chart configuration.
+
+Once the feature gate is disabled, {product_name} will automatically remove the `provisioning.cattle.io/externally-managed` annotation from any previously managed clusters, and Rancher will resume responsibility for installing and managing the Fleet agent on the workload clusters.


### PR DESCRIPTION
When set to true, use-caapf must be set prior to upgrade.

Fixes https://github.com/rancher/turtles/issues/2321