### PR TITLE
managed and self-managed gcp clusters are supported

### DIFF
--- a/versions/v0.25/modules/en/pages/overview/certified.adoc
+++ b/versions/v0.25/modules/en/pages/overview/certified.adoc
@@ -85,7 +85,7 @@ ifeval::["{build-type}" == "product"]
 |{azure_version}
 endif::[]
 
-| *GCP* (Only GKE managed clusters)
+| *GCP*
 | CAPG
 | Infrastructure
 | https://cluster-api-gcp.sigs.k8s.io/[CAPG book]

--- a/versions/v0.26/modules/en/pages/overview/certified.adoc
+++ b/versions/v0.26/modules/en/pages/overview/certified.adoc
@@ -86,7 +86,7 @@ ifeval::["{build-type}" == "product"]
 |{azure_version}
 endif::[]
 
-| *GCP* (Only GKE managed clusters)
+| *GCP*
 | CAPG
 | Infrastructure
 | https://cluster-api-gcp.sigs.k8s.io/[CAPG book]

--- a/versions/v0.27/modules/en/pages/overview/certified.adoc
+++ b/versions/v0.27/modules/en/pages/overview/certified.adoc
@@ -85,7 +85,7 @@ ifeval::["{build-type}" == "product"]
 |{azure_version}
 endif::[]
 
-| *GCP* (Only GKE managed clusters)
+| *GCP*
 | CAPG
 | Infrastructure
 | https://cluster-api-gcp.sigs.k8s.io/[CAPG book]


### PR DESCRIPTION
# Description

Remove not that claims that only managed clusters are supported when using CAPG with Turtles. This was the case in the past but both cluster types have been supported for a long time.

This PR edits all versions of Turtles since it became part of Rancher.