### PR TITLE
Adding release notes v0.26.2

### DIFF
--- a/versions/v0.26/antora-yml/antora-community.yml
+++ b/versions/v0.26/antora-yml/antora-community.yml
@@ -9,6 +9,6 @@ asciidoc:
     product_name: Rancher Turtles
     #Prerequisite and Component version attributes
     rancher_version: v2.14.0
-    turtles_version: v0.26.1
+    turtles_version: v0.26.2
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.26/antora-yml/antora-product.yml
+++ b/versions/v0.26/antora-yml/antora-product.yml
@@ -9,7 +9,7 @@ asciidoc:
     product_name: SUSE® Rancher Prime Cluster API
     #Prerequisite and Component version attributes
     rancher_version: v2.14.0
-    turtles_version: v0.26.1
+    turtles_version: v0.26.2
     aws_version: "v2.11.1"
     azure_version: v1.22.0
     gcp_version: v1.11.1

--- a/versions/v0.26/modules/de/nav.adoc
+++ b/versions/v0.26/modules/de/nav.adoc
@@ -35,4 +35,6 @@ endif::[]
 * Sicherheit
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Versionshinweise]
-** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
+** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/en/nav.adoc
+++ b/versions/v0.26/modules/en/nav.adoc
@@ -35,5 +35,6 @@ endif::[]
 * Security
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Release Notes]
-** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/en/pages/changelogs/changelogs/v0.26.2.adoc
+++ b/versions/v0.26/modules/en/pages/changelogs/changelogs/v0.26.2.adoc
@@ -1,0 +1,42 @@
+= v0.26.2
+:revdate: 2026-05-28
+:page-revdate: {revdate}
+
+== Release Date: 2026-05-22
+
+== Description
+
+[IMPORTANT]
+====
+Please read below information before updating.
+====
+
+**Cluster API Add-on Provider for Fleet (CAAPF)** is deprecated as of {product_name} v0.26.1 (Rancher v2.14.1) and is no longer installed by default. We encourage you to move away from CAAPF in preparation for its eventual removal (following Rancher deprecation policies). If you wish to continue using it, refer to the xref:user/caapf.adoc[CAAPF user guide] for more information.
+
+=== Notable Changes
+
+* Bump core CAPI to v1.12.7 by @salasberryfin in https://github.com/rancher/turtles/pull/2389[#2389]
+* Bump CAPI operator to v0.27.0 by @salasberryfin in https://github.com/rancher/turtles/pull/2387[#2387]
+* Bump CAPRKE2 to v0.24.4 by @rancher-backport-assistant[bot] in https://github.com/rancher/turtles/pull/2393[#2393]
+* Bump CAPA to v2.10.1 by @rancher-backport-assistant[bot] in https://github.com/rancher/turtles/pull/2158[#2158]
+
+==== Security
+
+* Bump go to 1.25.10 by @rancher-backport-assistant[bot] in https://github.com/rancher/turtles/pull/2384[#2384]
+* Use publish image action in release workflow by @furkatgofurov7 in https://github.com/rancher/turtles/pull/2362[#2362]
+
+==== Full Changelog: 
+
+Review the full list of changes: https://github.com/rancher/turtles/compare/v0.26.1%E2%80%A6v0.26.2[v0.26.1...v0.26.2]
+
+== Download
+
+[cols="3,1,1" options="header" frame="all" grid="rows"]
+|===
+| Name | Created At | Updated At
+
+| link:https://github.com/rancher/turtles/releases/download/v0.26.2/rancher-turtles-0.26.2.tgz[rancher-turtles-0.26.2.tgz] | 2026-05-22 | 2026-05-22
+
+|===
+
+__Information retrieved from https://github.com/rancher/turtles/releases/tag/v0.26.2[v0.26.2 GitHub release].__

--- a/versions/v0.26/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.26/modules/en/pages/changelogs/index.adoc
@@ -1,7 +1,8 @@
 = Release Notes
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-27
+:revdate: 2026-05-28
 :page-revdate: {revdate}
 
-* xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1 (latest)]
+* xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+* xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 * xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/es/nav.adoc
+++ b/versions/v0.26/modules/es/nav.adoc
@@ -35,4 +35,6 @@ endif::[]
 * Seguridad
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Notas de la versión]
-** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
+** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/fr/nav.adoc
+++ b/versions/v0.26/modules/fr/nav.adoc
@@ -35,4 +35,6 @@ endif::[]
 * Sécurité
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[notes de version]
-** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
+** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/ja/nav.adoc
+++ b/versions/v0.26/modules/ja/nav.adoc
@@ -35,4 +35,6 @@ endif::[]
 * セキュリティ
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[リリースノート]
-** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
+** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/pt/nav.adoc
+++ b/versions/v0.26/modules/pt/nav.adoc
@@ -35,4 +35,6 @@ endif::[]
 * Segurança
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Notas de versão]
-** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
+** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/zh/nav.adoc
+++ b/versions/v0.26/modules/zh/nav.adoc
@@ -35,4 +35,6 @@ endif::[]
 * 安全性
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[发行说明]
-** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
+** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]


### PR DESCRIPTION
Adding v0.26.2 release notes. Updating translations and playbook attribute.

Based on https://github.com/rancher/turtles/tree/v0.26.2 and https://github.com/rancher/turtles/releases/tag/v0.26.2