### PR TITLE
Adding Release Notes v0.26.3 / v0.25.5

### DIFF
--- a/versions/v0.25/antora-yml/antora-community.yml
+++ b/versions/v0.25/antora-yml/antora-community.yml
@@ -9,6 +9,6 @@ asciidoc:
     product_name: Rancher Turtles
     #Prerequisite and Component version attributes
     rancher_version: v2.13.3
-    turtles_version: v0.25.4
+    turtles_version: v0.25.5
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.25/antora-yml/antora-product.yml
+++ b/versions/v0.25/antora-yml/antora-product.yml
@@ -9,7 +9,7 @@ asciidoc:
     product_name: SUSE® Rancher Prime Cluster API
     #Prerequisite and Component version attributes
     rancher_version: v2.13.3
-    turtles_version: v0.25.4
+    turtles_version: v0.25.5
     aws_version: v2.9.1
     azure_version: v1.21.0
     gcp_version: v1.10.0

--- a/versions/v0.25/modules/en/nav.adoc
+++ b/versions/v0.25/modules/en/nav.adoc
@@ -36,6 +36,7 @@ endif::[]
 * Security
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Release Notes]
+** xref:changelogs/changelogs/v0.25.5.adoc[v0.25.5]
 ** xref:changelogs/changelogs/v0.25.4.adoc[v0.25.4]
 ** xref:changelogs/changelogs/v0.25.3.adoc[v0.25.3]
 ** xref:changelogs/changelogs/v0.25.2.adoc[v0.25.2]

--- a/versions/v0.25/modules/en/pages/changelogs/changelogs/v0.25.5.adoc
+++ b/versions/v0.25/modules/en/pages/changelogs/changelogs/v0.25.5.adoc
@@ -1,0 +1,32 @@
+= v0.25.5
+:revdate: 2026-06-18
+:page-revdate: {revdate}
+
+== Release Date: 2026-06-17
+
+== Description
+
+This is a maintenance release that delivers security and dependency updates.
+
+=== Notable Changes
+
+* Bump go.opentelemetry.io/otel dependencies to v1.40.0.
+* Bump rancher/kuberlr-kubectl to v6.1.0.
+* Bump github.com/go-git/go-git/v5 to v5.19.1 in test package.
+* Several release process improvements.
+
+==== Full Changelog: 
+
+Review the full list of changes: https://github.com/rancher/turtles/compare/v0.25.4%E2%80%A6v0.25.5[v0.25.4...v0.25.5]
+
+== Download
+
+[cols="3,1,1" options="header" frame="all" grid="rows"]
+|===
+| Name | Created At | Updated At
+
+| link:https://github.com/rancher/turtles/releases/download/v0.25.5/rancher-turtles-0.25.5.tgz[rancher-turtles-0.25.5.tgz] | 2026-06-18 | 2026-06-18
+
+|===
+
+__Information retrieved from https://github.com/rancher/turtles/releases/tag/v0.25.5[v0.25.5 GitHub release].__

--- a/versions/v0.25/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.25/modules/en/pages/changelogs/index.adoc
@@ -1,6 +1,8 @@
 = Release Notes
-:revdate: 2026-03-23
+:revdate: 2026-06-18
 :page-revdate: {revdate}
+
+* xref:changelogs/changelogs/v0.25.5.adoc[v0.25.5]
 
 * xref:changelogs/changelogs/v0.25.4.adoc[v0.25.4]
 

--- a/versions/v0.26/antora-yml/antora-community.yml
+++ b/versions/v0.26/antora-yml/antora-community.yml
@@ -9,6 +9,6 @@ asciidoc:
     product_name: Rancher Turtles
     #Prerequisite and Component version attributes
     rancher_version: v2.14.0
-    turtles_version: v0.26.2
+    turtles_version: v0.26.3
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.26/antora-yml/antora-product.yml
+++ b/versions/v0.26/antora-yml/antora-product.yml
@@ -9,7 +9,7 @@ asciidoc:
     product_name: SUSE® Rancher Prime Cluster API
     #Prerequisite and Component version attributes
     rancher_version: v2.14.0
-    turtles_version: v0.26.2
+    turtles_version: v0.26.3
     aws_version: "v2.11.1"
     azure_version: v1.22.0
     gcp_version: v1.11.1

--- a/versions/v0.26/modules/de/nav.adoc
+++ b/versions/v0.26/modules/de/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * Sicherheit
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Versionshinweise]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/en/nav.adoc
+++ b/versions/v0.26/modules/en/nav.adoc
@@ -36,6 +36,7 @@ endif::[]
 * Security
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Release Notes]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/en/pages/changelogs/changelogs/v0.26.3.adoc
+++ b/versions/v0.26/modules/en/pages/changelogs/changelogs/v0.26.3.adoc
@@ -10,9 +10,9 @@ This maintenance release primarily focuses on resolving security vulnerabilities
 
 === Notable Changes
 
-* Bump Go version to v1.25.11
-* Bump rancher/kuberlr-kubectl to v7.1.0
-* Bump k8s.io/* dependencies to v0.34.8
+* Bump Go version to v1.25.11.
+* Bump rancher/kuberlr-kubectl to v7.1.0.
+* Bump k8s.io/* dependencies to v0.34.8.
 
 ==== Full Changelog: 
 

--- a/versions/v0.26/modules/en/pages/changelogs/changelogs/v0.26.3.adoc
+++ b/versions/v0.26/modules/en/pages/changelogs/changelogs/v0.26.3.adoc
@@ -1,0 +1,31 @@
+= v0.26.3
+:revdate: 2026-06-18
+:page-revdate: {revdate}
+
+== Release Date: 2026-06-18
+
+== Description
+
+This maintenance release primarily focuses on resolving security vulnerabilities and updating dependencies, including key updates to Kubernetes libraries alongside development and testing toolchains.
+
+=== Notable Changes
+
+* Bump Go version to v1.25.11
+* Bump rancher/kuberlr-kubectl to v7.1.0
+* Bump k8s.io/* dependencies to v0.34.8
+
+==== Full Changelog: 
+
+Review the full list of changes: https://github.com/rancher/turtles/compare/v0.26.2%E2%80%A6v0.26.3[v0.26.2...v0.26.3]
+
+== Download
+
+[cols="3,1,1" options="header" frame="all" grid="rows"]
+|===
+| Name | Created At | Updated At
+
+| link:https://github.com/rancher/turtles/releases/download/v0.26.3/rancher-turtles-0.26.3.tgz[rancher-turtles-0.26.3.tgz] | 2026-06-18 | 2026-06-18
+
+|===
+
+__Information retrieved from https://github.com/rancher/turtles/releases/tag/v0.26.3[v0.26.3 GitHub release].__

--- a/versions/v0.26/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.26/modules/en/pages/changelogs/index.adoc
@@ -1,8 +1,9 @@
 = Release Notes
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-28
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
-* xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+* xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+* xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 * xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 * xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/es/nav.adoc
+++ b/versions/v0.26/modules/es/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * Seguridad
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Notas de la versión]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/fr/nav.adoc
+++ b/versions/v0.26/modules/fr/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * Sécurité
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[notes de version]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/ja/nav.adoc
+++ b/versions/v0.26/modules/ja/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * セキュリティ
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[リリースノート]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/pt/nav.adoc
+++ b/versions/v0.26/modules/pt/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * Segurança
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Notas de versão]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]

--- a/versions/v0.26/modules/zh/nav.adoc
+++ b/versions/v0.26/modules/zh/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * 安全性
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[发行说明]
-** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2 (latest)]
+** xref:changelogs/changelogs/v0.26.3.adoc[v0.26.3 (latest)]
+** xref:changelogs/changelogs/v0.26.2.adoc[v0.26.2]
 ** xref:changelogs/changelogs/v0.26.1.adoc[v0.26.1]
 ** xref:changelogs/changelogs/v0.26.0.adoc[v0.26.0]


### PR DESCRIPTION
Adding v0.26.3 / v0.25.5 release notes. Updating translations and playbook attribute.

Based on https://github.com/rancher/turtles/tree/v0.26.3 and https://github.com/rancher/turtles/releases/tag/v0.26.3
Based on https://github.com/rancher/turtles/tree/v0.25.5 and https://github.com/rancher/turtles/releases/tag/v0.25.5