### PR TITLE
Dependabot: apply update cooldown to all github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,3 @@ updates:
       - "area/build-and-release"
     cooldown:
       default-days: 7
-      include:
-        - "actions/checkout"
-        - "actions/setup-node"


### PR DESCRIPTION
Exclusion should be used instead when needed (e.g. our own actions)