### PR TITLE
Adding v0.24.5 release information

### DIFF
--- a/versions/v0.24/antora-yml/antora-community.yml
+++ b/versions/v0.24/antora-yml/antora-community.yml
@@ -12,8 +12,8 @@ asciidoc:
     cluster_api_version: v1.10.5
     cluster_api_provider_RKE2_version: v0.20.1
     helm_version: v3.17.1
-    k8s_cluster_version: v1.31.4
-    rancher_version: v2.12.3
-    turtles_version: v0.24.4
+    k8s_cluster_version: v1.33.5
+    rancher_version: v2.12.4
+    turtles_version: v0.24.5
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.24/antora-yml/antora-product.yml
+++ b/versions/v0.24/antora-yml/antora-product.yml
@@ -12,8 +12,8 @@ asciidoc:
     cluster_api_version: v1.10.5
     cluster_api_provider_RKE2_version: v0.20.1
     helm_version: v3.17.1
-    k8s_cluster_version: v1.31.4
-    rancher_version: v2.12.3
-    turtles_version: v0.24.4
+    k8s_cluster_version: v1.33.11
+    rancher_version: v2.12.10
+    turtles_version: v0.24.5
 nav:
   - modules/en/nav.adoc

--- a/versions/v0.24/modules/en/nav.adoc
+++ b/versions/v0.24/modules/en/nav.adoc
@@ -35,6 +35,7 @@ endif::[]
 * Security
 ** xref:security/slsa.adoc[SLSA]
 * xref:changelogs/index.adoc[Release Notes]
+** xref:changelogs/changelogs/v0.24.5.adoc[v0.24.5]
 ** xref:changelogs/changelogs/v0.24.4.adoc[v0.24.4]
 ** xref:changelogs/changelogs/v0.24.3.adoc[v0.24.3]
 ** xref:changelogs/changelogs/v0.24.2.adoc[v0.24.2]

--- a/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.24.5.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/changelogs/v0.24.5.adoc
@@ -1,0 +1,31 @@
+= v0.24.5
+:revdate: 2026-06-29
+:page-revdate: {revdate}
+
+== Release Date: 2026-06-24
+
+== Description
+
+{product_name} - Cluster API integration in Rancher.
+
+=== What's Changed
+
+This is a patch release that bumps dependencies to patch security issues.
+
+* Bump dependencies to fix security issues by @furkatgofurov7 in https://github.com/rancher/turtles/pull/2482[#2482].
+
+==== Full Changelog: 
+
+Review the full list of changes: https://github.com/rancher/turtles/compare/v0.24.4%E2%80%A6v0.24.5[v0.24.4...v0.24.5]
+
+== Download
+
+[cols="3,1,1" options="header" frame="all" grid="rows"]
+|===
+| Name | Created At | Updated At
+
+| link:https://github.com/rancher/turtles/releases/download/v0.24.5/rancher-turtles-0.24.5.tgz[rancher-turtles-0.24.5.tgz] | 2026-06-24 | 2026-06-24
+
+|===
+
+__Information retrieved from https://github.com/rancher/turtles/releases/tag/v0.24.5[v0.24.5 GitHub release].__

--- a/versions/v0.24/modules/en/pages/changelogs/index.adoc
+++ b/versions/v0.24/modules/en/pages/changelogs/index.adoc
@@ -1,6 +1,8 @@
 = Release Notes
-:revdate: 2026-02-03
+:revdate: 2026-06-29
 :page-revdate: {revdate}
+
+* xref:changelogs/changelogs/v0.24.5.adoc[v0.24.5]
 
 * xref:changelogs/changelogs/v0.24.4.adoc[v0.24.4]
 


### PR DESCRIPTION
v0.24.5 release info, references:

https://github.com/rancher/turtles/releases/tag/v0.24.5
https://github.com/rancher/turtles/tree/v0.24.5